### PR TITLE
Specify error message for unmatched sells and avoid exception propagation from BilanceQueue

### DIFF
--- a/src/book.py
+++ b/src/book.py
@@ -50,7 +50,8 @@ class Book:
             # Skip header.
             next(reader)
 
-            for row, (_utc_time, account, operation, coin, _change, remark) in enumerate(reader, 2):
+            for _utc_time, account, operation, coin, _change, remark in reader:
+                row = reader.line_num
                 # Parse data.
                 utc_time = datetime.datetime.strptime(
                     _utc_time, "%Y-%m-%d %H:%M:%S")
@@ -73,7 +74,7 @@ class Book:
                 # Check for problems.
                 if remark:
                     log.warning(
-                        "I may missed a remark in %s:%i: `%s`.", file_path, row, remark)
+                        "I may have missed a remark in %s:%i: `%s`.", file_path, row, remark)
 
                 # Append operation to the correct list.
                 try:
@@ -83,7 +84,7 @@ class Book:
                         "Could not recognize operation `%s` in binance file `%s:%i`.", operation, file_path, row)
                     continue
 
-                o = Op(utc_time, platform, change, coin)
+                o = Op(utc_time, platform, change, coin, row, file_path)
                 self.operations.append(o)
 
     def detect_exchange(self, file_path: Path) -> Optional[str]:

--- a/src/taxman.py
+++ b/src/taxman.py
@@ -77,13 +77,15 @@ class Taxman:
             elif isinstance(op, Buy):
                 bilance.put(op)
             elif isinstance(op, Sell):
-                try:
-                    sold_coins = bilance.sell(op.change)
-                except IndexError:
+                sold_coins = bilance.sell(op.change)
+                if sold_coins is None:
+                    # Queue ran out of items to sell...
                     if coin == config.FIAT:
+                        # ...this is OK for fiat currencies (not taxable)
                         continue
-                    raise RuntimeError(
-                        f"Not enough {coin} in queue to sell (transaction from {op.utc_time} on {op.platform}).\nHave you forgotten to add all account statements?\nThis error could occure after deposits from unknown sources.")
+                    else:
+                        raise RuntimeError(
+                            f"Not enough {coin} in queue to sell (transaction from {op.utc_time} on {op.platform}).\nHave you forgotten to add all account statements?\nThis error could occure after deposits from unknown sources.")
                 if self.in_tax_year(op) and coin != config.FIAT:
                     taxation_type = "Sonstige Einkünfte"
                     # Price of the sell.

--- a/src/taxman.py
+++ b/src/taxman.py
@@ -84,8 +84,14 @@ class Taxman:
                         # ...this is OK for fiat currencies (not taxable)
                         continue
                     else:
-                        raise RuntimeError(
-                            f"Not enough {coin} in queue to sell (transaction from {op.utc_time} on {op.platform}).\nHave you forgotten to add all account statements?\nThis error could occure after deposits from unknown sources.")
+                        # ...but not for crypto coins (taxable)
+                        log.error(
+                            f"{op.file_path.name}: Line {op.line}: "
+                            f"Not enough {coin} in queue to sell (transaction from {op.utc_time} on {op.platform})\n"
+                            f"\tIs your account statement missing any transactions?\n"
+                            f"\tThis error may also occur after deposits from unknown sources.\n"
+                        )
+                        raise RuntimeError
                 if self.in_tax_year(op) and coin != config.FIAT:
                     taxation_type = "Sonstige Einkünfte"
                     # Price of the sell.

--- a/src/transaction.py
+++ b/src/transaction.py
@@ -19,6 +19,7 @@ import dataclasses
 import datetime
 import logging
 import typing
+from pathlib import Path
 
 log = logging.getLogger(__name__)
 
@@ -29,6 +30,8 @@ class Operation:
     platform: str
     change: float
     coin: str
+    line: int
+    file_path: Path
 
     def __post_init__(self):
         assert self.validate_types()


### PR DESCRIPTION
Even more specific error message on unmatched sells; replaced corresponding exception propagation.