### PR TITLE
Add "Cash Voucher distribution" operation mapping for Binance

### DIFF
--- a/src/book.py
+++ b/src/book.py
@@ -75,6 +75,7 @@ class Book:
             "Commission History": "Commission",
             "Commission Fee Shared With You": "Commission",
             "Launchpool Interest": "StakingInterest",
+            "Cash Voucher distribution": "Airdrop",
         }
 
         with open(file_path, encoding="utf8") as f:


### PR DESCRIPTION
Saw this in my exports and mapped it to Airdrop, as explained by Binance:

> The Cash voucher is an airdrop that will be credited to your corresponding account once you redeem it. 

https://www.binance.com/en/blog/421499824684900770/The-Ultimate-Guide-to-Binance-Vouchers