### PR TITLE
Add Coinbase Pro and extend Coinbase support

### DIFF
--- a/src/book.py
+++ b/src/book.py
@@ -128,7 +128,7 @@ class Book:
         operation_mapping = {
             "Receive": "Deposit",
             "Send": "Withdraw",
-            "Coinbase Earn": "Buy"
+            "Coinbase Earn": "Buy",
         }
 
         with open(file_path, encoding="utf8") as f:
@@ -197,16 +197,24 @@ class Book:
 
                 if operation == "Convert":
                     # parse change + coin from remark which is in format "0,123 ETH to 0,456 BTC"
-                    remark_target = remark.split(' to ')[-1]
-                    remark_target_parts = remark_target.split(' ')
-                    _convert_change = remark_target_parts[0].replace(',', '.')
+                    remark_target = remark.split(" to ")[-1]
+                    remark_target_parts = remark_target.split(" ")
+                    _convert_change = remark_target_parts[0].replace(",", ".")
                     convert_change = misc.xdecimal(_convert_change)
                     convert_coin = remark_target_parts[1]
 
-                    self.append_operation("Sell", utc_time, platform,
-                                          change, coin, row, file_path)
-                    self.append_operation("Buy", utc_time, platform,
-                                          convert_change, convert_coin, row, file_path)
+                    self.append_operation(
+                        "Sell", utc_time, platform, change, coin, row, file_path
+                    )
+                    self.append_operation(
+                        "Buy",
+                        utc_time,
+                        platform,
+                        convert_change,
+                        convert_coin,
+                        row,
+                        file_path,
+                    )
                 else:
                     self.append_operation(
                         operation, utc_time, platform, change, coin, row, file_path
@@ -215,12 +223,24 @@ class Book:
                     if operation == "Sell":
                         assert isinstance(eur_subtotal, decimal.Decimal)
                         self.append_operation(
-                            "Buy", utc_time, platform, eur_subtotal, "EUR", row, file_path
+                            "Buy",
+                            utc_time,
+                            platform,
+                            eur_subtotal,
+                            "EUR",
+                            row,
+                            file_path,
                         )
                     elif operation == "Buy":
                         assert isinstance(eur_subtotal, decimal.Decimal)
                         self.append_operation(
-                            "Sell", utc_time, platform, eur_subtotal, "EUR", row, file_path
+                            "Sell",
+                            utc_time,
+                            platform,
+                            eur_subtotal,
+                            "EUR",
+                            row,
+                            file_path,
                         )
 
                     if eur_fee:
@@ -241,12 +261,25 @@ class Book:
             # Skip header.
             next(reader)
 
-            for portfolio, trade_id, product, operation, _utc_time, _size, size_unit, _price, _fee, total, price_fee_total_unit in reader:
+            for (
+                portfolio,
+                trade_id,
+                product,
+                operation,
+                _utc_time,
+                _size,
+                size_unit,
+                _price,
+                _fee,
+                total,
+                price_fee_total_unit,
+            ) in reader:
                 row = reader.line_num
 
                 # Parse data.
                 utc_time = datetime.datetime.strptime(
-                    _utc_time, "%Y-%m-%dT%H:%M:%S.%fZ")
+                    _utc_time, "%Y-%m-%dT%H:%M:%S.%fZ"
+                )
                 utc_time = utc_time.replace(tzinfo=datetime.timezone.utc)
                 operation = operation_mapping.get(operation, operation)
                 size = misc.xdecimal(_size)
@@ -266,18 +299,40 @@ class Book:
                 assert size_unit
                 assert price_fee_total_unit
 
-                self.append_operation(operation, utc_time, platform,
-                                      size, size_unit, row, file_path)
+                self.append_operation(
+                    operation, utc_time, platform, size, size_unit, row, file_path
+                )
 
                 if operation == "Sell":
-                    self.append_operation("Buy", utc_time, platform,
-                                          total_price, price_fee_total_unit, row, file_path)
+                    self.append_operation(
+                        "Buy",
+                        utc_time,
+                        platform,
+                        total_price,
+                        price_fee_total_unit,
+                        row,
+                        file_path,
+                    )
                 elif operation == "Buy":
-                    self.append_operation("Sell", utc_time, platform,
-                                          total_price, price_fee_total_unit, row, file_path)
+                    self.append_operation(
+                        "Sell",
+                        utc_time,
+                        platform,
+                        total_price,
+                        price_fee_total_unit,
+                        row,
+                        file_path,
+                    )
                 if fee:
-                    self.append_operation("Fee", utc_time, platform,
-                                          fee, price_fee_total_unit, row, file_path)
+                    self.append_operation(
+                        "Fee",
+                        utc_time,
+                        platform,
+                        fee,
+                        price_fee_total_unit,
+                        row,
+                        file_path,
+                    )
 
     def _read_kraken_trades(self, file_path: Path) -> None:
         log.error(

--- a/src/book.py
+++ b/src/book.py
@@ -196,11 +196,12 @@ class Book:
                 assert change
 
                 if operation == "Convert":
-                    # parse change + coin from remark which is in format "0,123 ETH to 0,456 BTC"
+                    # parse change + coin from remark which is
+                    # in format "0,123 ETH to 0,456 BTC"
                     remark_target = remark.split(" to ")[-1]
                     remark_target_parts = remark_target.split(" ")
                     _convert_change = remark_target_parts[0].replace(",", ".")
-                    convert_change = misc.xdecimal(_convert_change)
+                    convert_change = misc.force_decimal(_convert_change)
                     convert_coin = remark_target_parts[1]
 
                     self.append_operation(
@@ -282,8 +283,8 @@ class Book:
                 )
                 utc_time = utc_time.replace(tzinfo=datetime.timezone.utc)
                 operation = operation_mapping.get(operation, operation)
-                size = misc.xdecimal(_size)
-                price = misc.xdecimal(_price)
+                size = misc.force_decimal(_size)
+                price = misc.force_decimal(_price)
                 fee = misc.xdecimal(_fee)
                 total_price = size * price
 

--- a/src/book.py
+++ b/src/book.py
@@ -18,6 +18,7 @@ import csv
 import datetime
 import decimal
 import logging
+import re
 from pathlib import Path
 from typing import Optional
 
@@ -198,12 +199,17 @@ class Book:
 
                 if operation == "Convert":
                     # Parse change + coin from remark, which is
-                    # in format "0,123 ETH to 0,456 BTC".
-                    remark_target = remark.split(" to ")[-1]
-                    remark_target_parts = remark_target.split(" ")
-                    _convert_change = remark_target_parts[0].replace(",", ".")
+                    # in format "Converted 0,123 ETH to 0,456 BTC".
+                    match = re.match(
+                        r"^Converted [0-9,\.]+ [A-Z]+ to "
+                        + r"(?P<change>[0-9,\.]+) (?P<coin>[A-Z]+)$",
+                        remark,
+                    )
+                    assert match
+
+                    _convert_change = match.group("change").replace(",", ".")
                     convert_change = misc.force_decimal(_convert_change)
-                    convert_coin = remark_target_parts[1]
+                    convert_coin = match.group("coin")
 
                     eur_total = misc.force_decimal(_eur_total)
                     convert_eur_spot = eur_total / convert_change

--- a/src/book.py
+++ b/src/book.py
@@ -195,7 +195,7 @@ class Book:
                 assert change
 
                 if operation == "Convert":
-                    # parse buy change + coin from remark which is in format "0,123 ETH to 0,456 BTC"
+                    # parse change + coin from remark which is in format "0,123 ETH to 0,456 BTC"
                     remark_target = remark.split(' to ')[-1]
                     remark_target_parts = remark_target.split(' ')
                     _convert_change = remark_target_parts[0].replace(',', '.')

--- a/src/book.py
+++ b/src/book.py
@@ -125,7 +125,9 @@ class Book:
     def _read_coinbase(self, file_path: Path) -> None:
         platform = "coinbase"
         operation_mapping = {
+            "Receive": "Deposit",
             "Send": "Withdraw",
+            "Coinbase Earn": "Buy"
         }
 
         with open(file_path, encoding="utf8") as f:
@@ -178,8 +180,6 @@ class Book:
                 utc_time = utc_time.replace(tzinfo=datetime.timezone.utc)
                 operation = operation_mapping.get(operation, operation)
                 change = misc.force_decimal(_change)
-                #  Current price from exchange.
-                eur_spot = misc.force_decimal(_eur_spot)
                 #  Cost without fees.
                 eur_subtotal = misc.xdecimal(_eur_subtotal)
                 #  Cost with fees.
@@ -188,36 +188,95 @@ class Book:
 
                 # Unused variables.
                 del eur_total
-                del remark
 
                 # Validate data.
                 assert operation
                 assert coin
                 assert change
-                assert eur_spot
 
-                self.append_operation(
-                    operation, utc_time, platform, change, coin, row, file_path
-                )
+                if operation == "Convert":
+                    # parse buy change + coin from remark which is in format "0,123 ETH to 0,456 BTC"
+                    remark_target = remark.split(' to ')[-1]
+                    remark_target_parts = remark_target.split(' ')
+                    _convert_change = remark_target_parts[0].replace(',', '.')
+                    convert_change = misc.xdecimal(_convert_change)
+                    convert_coin = remark_target_parts[1]
 
-                # Save price in our local database for later.
-                self.price_data.set_price_db(platform, coin, "EUR", utc_time, eur_spot)
+                    self.append_operation("Sell", utc_time, platform,
+                                          change, coin, row, file_path)
+                    self.append_operation("Buy", utc_time, platform,
+                                          convert_change, convert_coin, row, file_path)
+                else:
+                    self.append_operation(
+                        operation, utc_time, platform, change, coin, row, file_path
+                    )
+
+                    if operation == "Sell":
+                        assert isinstance(eur_subtotal, decimal.Decimal)
+                        self.append_operation(
+                            "Buy", utc_time, platform, eur_subtotal, "EUR", row, file_path
+                        )
+                    elif operation == "Buy":
+                        assert isinstance(eur_subtotal, decimal.Decimal)
+                        self.append_operation(
+                            "Sell", utc_time, platform, eur_subtotal, "EUR", row, file_path
+                        )
+
+                    if eur_fee:
+                        self.append_operation(
+                            "Fee", utc_time, platform, eur_fee, "EUR", row, file_path
+                        )
+
+    def _read_coinbase_pro(self, file_path: Path) -> None:
+        platform = "coinbase_pro"
+        operation_mapping = {
+            "BUY": "Buy",
+            "SELL": "Sell",
+        }
+
+        with open(file_path, encoding="utf8") as f:
+            reader = csv.reader(f)
+
+            # Skip header.
+            next(reader)
+
+            for portfolio, trade_id, product, operation, _utc_time, _size, size_unit, _price, _fee, total, price_fee_total_unit in reader:
+                row = reader.line_num
+
+                # Parse data.
+                utc_time = datetime.datetime.strptime(
+                    _utc_time, "%Y-%m-%dT%H:%M:%S.%fZ")
+                utc_time = utc_time.replace(tzinfo=datetime.timezone.utc)
+                operation = operation_mapping.get(operation, operation)
+                size = misc.xdecimal(_size)
+                price = misc.xdecimal(_price)
+                fee = misc.xdecimal(_fee)
+                total_price = size * price
+
+                # Unused variables.
+                del portfolio
+                del trade_id
+                del product
+                del total
+
+                # Validate data.
+                assert operation
+                assert size
+                assert size_unit
+                assert price_fee_total_unit
+
+                self.append_operation(operation, utc_time, platform,
+                                      size, size_unit, row, file_path)
 
                 if operation == "Sell":
-                    assert isinstance(eur_subtotal, decimal.Decimal)
-                    self.append_operation(
-                        "Buy", utc_time, platform, eur_subtotal, "EUR", row, file_path
-                    )
+                    self.append_operation("Buy", utc_time, platform,
+                                          total_price, price_fee_total_unit, row, file_path)
                 elif operation == "Buy":
-                    assert isinstance(eur_subtotal, decimal.Decimal)
-                    self.append_operation(
-                        "Sell", utc_time, platform, eur_subtotal, "EUR", row, file_path
-                    )
-
-                if eur_fee:
-                    self.append_operation(
-                        "Fee", utc_time, platform, eur_fee, "EUR", row, file_path
-                    )
+                    self.append_operation("Sell", utc_time, platform,
+                                          total_price, price_fee_total_unit, row, file_path)
+                if fee:
+                    self.append_operation("Fee", utc_time, platform,
+                                          fee, price_fee_total_unit, row, file_path)
 
     def _read_kraken_trades(self, file_path: Path) -> None:
         log.error(
@@ -382,6 +441,19 @@ class Book:
                     "Converts, and Rewards Income, and Coinbase Earn "
                     "transactions are taxable events. For final tax "
                     "obligations, please consult your tax advisor."
+                ],
+                "coinbase_pro": [
+                    "portfolio",
+                    "trade id",
+                    "product",
+                    "side",
+                    "created at",
+                    "size",
+                    "size unit",
+                    "price",
+                    "fee",
+                    "total",
+                    "price/fee/total unit",
                 ],
                 "kraken_ledgers_old": [
                     "txid",

--- a/src/misc.py
+++ b/src/misc.py
@@ -133,6 +133,18 @@ def get_offset_timestamps(
     return to_ms_timestamp(start), to_ms_timestamp(end)
 
 
+def to_iso_timestamp(d: datetime.datetime) -> str:
+    """Return timestamp as ISO8601 timestamp.
+
+    Args:
+        d (datetime.datetime)
+
+    Returns:
+        str: ISI8601 timestamp.
+    """
+    return d.isoformat().replace("+00:00", "Z")
+
+
 def group_by(lst: L, key: str) -> dict[str, L]:
     """Group a list of objects by `key`.
 

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -97,7 +97,7 @@ class PriceData:
             and data.get("code") == -1121
             and data.get("msg") == "Invalid symbol."
         ):
-            if quote_asset == "BTC" or base_asset == "BTC":
+            if quote_asset == "BTC":
                 # If we are already comparing with BTC, we might have to swap
                 # the assets to generate the correct symbol.
                 # Check a last time, if we find the pair by changing the symbol

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -134,19 +134,6 @@ class PriceData:
         return average_price
 
     @misc.delayed
-    def _get_price_coinbase(
-        self,
-        base_asset: str,
-        utc_time: datetime.datetime,
-        quote_asset: str,
-        swapped_symbols: bool = False,
-    ) -> decimal.Decimal:
-        # Use Coinbase Pro prices
-        return self._get_price_coinbase_pro(
-            base_asset, utc_time, quote_asset, swapped_symbols
-        )
-
-    @misc.delayed
     def _get_price_coinbase_pro(
         self,
         base_asset: str,

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -213,7 +213,7 @@ class PriceData:
 
         if len(data) == 0:
             log.warning("Coinbase Pro offers no price for `%s` at %s", symbol, utc_time)
-            return 0
+            return decimal.Decimal(0)
 
         # Find closest timestamp match
         target_timestamp = misc.to_ms_timestamp(utc_time)

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -142,8 +142,8 @@ class PriceData:
     def _get_price_coinbase_pro(self, base_asset: str, utc_time: datetime.datetime, quote_asset: str, swapped_symbols: bool = False) -> decimal.Decimal:
         """Retrieve price from Coinbase Pro official REST API.
 
-        The price is calculated as the average price in a
-        time frame of 1 minute around `utc_time`.
+        The price is calculated as the average price of the opening and closing price
+        around 1 minute around `utc_time`.
 
         None existing pairs like `TWTEUR` are calculated as
         `TWTBTC * BTCEUR`.
@@ -153,7 +153,7 @@ class PriceData:
         Args:
             start	        Start time in ISO 8601
             end	            End time in ISO 8601
-            granularity	    Desired timeslice in seconds (one of 60, 300, 900, 3600, 21600 or 86400)
+            granularity	    Desired timeslice in seconds (60, 300, 900, 3600, 21600 or 86400)
 
         Raises:
             RuntimeError: Unable to retrieve price data.
@@ -201,6 +201,7 @@ class PriceData:
             log.warning("Coinbase Pro offers no price for `%s` at %s", symbol, utc_time)
             return 0
 
+        # there's only one single item because we used 60s granularity with a 60s time window
         single_result = data[0]
         open_price = decimal.Decimal(single_result[3])
         close_price = decimal.Decimal(single_result[4])


### PR DESCRIPTION
The data of Coinbase Pro is supposed to be generated under [Profile > Statements](https://pro.coinbase.com/profile/statements) by clicking "Generate" > ~"Account"~ "Fills" and selecting CSV as the format.

The only remaining limitation is that Coinbase Pro API doesn't return data for XRP anymore, as discussed in #29 already.

Besides adding Coinbase Pro, there are some other minor changes in this PR as well.

1. I added `Receive` and `Coinbase Earn` operation mappings for Coinbase.
2. I also added `Convert` support for Coinbase, it was required to get the rates from somewhere. For consistency I've decided to never use the rates directly from the Coinbase CSV anymore and always get the pricing information from the Coinbase Pro API.
3. To avoid errors with my data, I needed to also check `base_asset` being `BTC` to swap the coins to get the correct pricing. I also applied this to the get price method of Binance.

I'd also suggest to update the Wiki for how to use both Coinbase and Coinbase Pro when this PR will be done.

I'm open to honest feedback as Python is not (yet?) my go to language 😊