### PR TITLE
Balance queue: fix LIFO queue and not_sold assertion

### DIFF
--- a/src/balance_queue.py
+++ b/src/balance_queue.py
@@ -124,7 +124,7 @@ class BalanceQueue:
                 return None
 
             not_sold = bop.op.change - bop.sold
-            assert not_sold >= 0
+            assert not_sold > 0
 
             if not_sold > change:
                 bop.sold += change

--- a/src/balance_queue.py
+++ b/src/balance_queue.py
@@ -18,7 +18,6 @@ import collections
 import dataclasses
 import decimal
 import logging
-import queue
 from typing import Deque, Optional, Union
 
 import transaction
@@ -139,11 +138,9 @@ class BalanceQueue:
         return sold_coins
 
 
-class BalanceLIFOQueue(queue.LifoQueue, BalanceQueue):
-    def _put(self, item: BalancedOperation) -> None:
-        self.queue.append(item)
-
-    def _get(self) -> BalancedOperation:
-        item = self.queue.pop()
-        assert isinstance(item, BalancedOperation)
-        return item
+class BalanceLIFOQueue(BalanceQueue):
+    def _get(self) -> Optional[BalancedOperation]:
+        try:
+            return self.queue.pop()
+        except IndexError:
+            return None

--- a/src/balance_queue.py
+++ b/src/balance_queue.py
@@ -124,7 +124,7 @@ class BalanceQueue:
                 return None
 
             not_sold = bop.op.change - bop.sold
-            assert not_sold > 0
+            assert not_sold >= 0
 
             if not_sold > change:
                 bop.sold += change


### PR DESCRIPTION
* The LIFO queue code seems to be outdated, so I fixed the inheritance and adapted the `_get` method.
* The `not_sold > 0`  assertion failed because it was exactly equal to `0`. I think this should also be fine.