### PR TITLE
Exchange bitpanda pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Pull Requests und Anfragen über Issues sind gerne gesehen (siehe `Key notes for
 
 ### Currently supported exchanges
 - [Binance](https://github.com/provinzio/CoinTaxman/wiki/Exchange:-Binance)
+- [Bitpanda Pro](https://github.com/provinzio/CoinTaxman/wiki/Exchange:-Bitpanda-Pro)
 - [coinbase](https://github.com/provinzio/CoinTaxman/wiki/Exchange:-coinbase)
 - [Kraken](https://github.com/provinzio/CoinTaxman/wiki/Exchange:-Kraken)
 

--- a/src/book.py
+++ b/src/book.py
@@ -435,21 +435,9 @@ class Book:
                     operation == "SELL" and fee_currency == price_currency) or (
                     operation == "BUY" and fee_currency == amount_currency)
 
-                # TODO: Need getpricedata for BEST
-                if fee_currency != "BEST":
-                    self.append_operation(
-                        "Fee", utc_time, platform,  misc.force_decimal(fee), fee_currency, row, file_path
-                    )
-                pass
-                # self.append_operation(
-                #     operation, utc_time, platform, change, coin, row, file_path
-                #
-
-                # if eur_fee:
-                #     self.append_operation(
-                #         "Fee", utc_time, platform, eur_fee, "EUR", row, file_path
-                #     )
-            return
+                self.append_operation(
+                    "Fee", utc_time, platform,  misc.force_decimal(fee), fee_currency, row, file_path
+                )
 
     def detect_exchange(self, file_path: Path) -> Optional[str]:
         if file_path.suffix == ".csv":

--- a/src/book.py
+++ b/src/book.py
@@ -375,31 +375,42 @@ class Book:
             # should be true in any case, since this has been dispatched here
             # so simply skip
             line = next(reader)
-            #assert line[0] == "Disclaimer: All data is without guarantee, errors and changes are reserved."
+            # assert line[0] == \
+            # "Disclaimer: ..."
 
             # for transactions, it's currently written "id" (small)
             line = next(reader)
             if line[0].startswith("Account id :"):
-                log.warning(f"{file_path} looks like a Bitpanda transaction file. Skipping.")
+                log.warning(
+                    f"{file_path} looks like a Bitpanda transaction file."
+                    " Skipping."
+                )
                 return
 
             assert line[0].startswith("Account ID:")
             line = next(reader)
-            # empty line - still keep this check in case Bitpanda changes the transaction file to match the
-            # trade header (casing)
+            # empty line - still keep this check in case Bitpanda changes the
+            # transaction file to match the trade header (casing)
             if not line:
-                log.warning(f"{file_path} looks like a Bitpanda transaction file. Skipping.")
+                log.warning(
+                    f"{file_path} looks like a Bitpanda transaction file. Skipping."
+                )
                 return
             elif line[0] != "Bitpanda Pro trade history":
-                log.warning(f"{file_path} doesn't look like a Bitpanda trade file. Skipping.")
+                log.warning(
+                    f"{file_path} doesn't look like a Bitpanda trade file. Skipping."
+                )
                 return
 
             line = next(reader)
-            assert line == ["Order ID","Trade ID","Type","Market","Amount","Amount Currency","Price","Price Currency","Fee","Fee Currency","Time (UTC)"]
+            assert line == [
+                "Order ID", "Trade ID", "Type", "Market", "Amount", "Amount Currency",
+                "Price", "Price Currency", "Fee", "Fee Currency", "Time (UTC)"
+            ]
 
             for (
-                order_id,
-                trace_id,
+                _order_id,
+                _trace_id,
                 operation,
                 trade_pair,
                 amount,
@@ -417,7 +428,7 @@ class Book:
 
                 utc_time = datetime.datetime.fromisoformat(_utc_time)
                 # not needed, already taken care of
-                #utc_time = utc_time.replace(tzinfo=datetime.timezone.utc)
+                # utc_time = utc_time.replace(tzinfo=datetime.timezone.utc)
 
                 # trade pair is of form e.g. BTC_EUR
                 assert [amount_currency, price_currency] == trade_pair.split("_")
@@ -431,7 +442,15 @@ class Book:
                 assert change > 0
 
                 # Add the BUY or SELL operation
-                self.append_operation(operation.title(), utc_time, platform, change, coin, row, file_path)
+                self.append_operation(
+                    operation.title(),
+                    utc_time,
+                    platform,
+                    change,
+                    coin,
+                    row,
+                    file_path
+                )
 
                 # only this is supported for now
                 # this is because _get_price_bitpanda_pro also needs to handle
@@ -448,7 +467,13 @@ class Book:
                     operation == "BUY" and fee_currency == amount_currency)
 
                 self.append_operation(
-                    "Fee", utc_time, platform,  misc.force_decimal(fee), fee_currency, row, file_path
+                    "Fee",
+                    utc_time,
+                    platform,
+                    misc.force_decimal(fee),
+                    fee_currency,
+                    row,
+                    file_path
                 )
 
     def detect_exchange(self, file_path: Path) -> Optional[str]:
@@ -512,7 +537,8 @@ class Book:
                     "ledgers",
                 ],
                 "bitpanda_pro_trades": [
-                    "Disclaimer: All data is without guarantee, errors and changes are reserved."
+                    "Disclaimer: All data is without guarantee,"
+                    " errors and changes are reserved."
                 ]
             }
             for exchange, expected in expected_headers.items():

--- a/src/book.py
+++ b/src/book.py
@@ -372,21 +372,18 @@ class Book:
         with open(file_path, encoding="utf8") as f:
             reader = csv.reader(f)
 
-            try:
-                # should be true in any case, since this has been dispatched here
-                line = next(reader)
-                assert line[0] == "Disclaimer: All data is without guarantee, errors and changes are reserved."
-                line = next(reader)
-                # for transactions, it's currently written "id" (small)
-                assert line[0].startswith("Account ID:")
-            except AssertionError as e:
-                msg = (
-                    "Unable to read Bitpanda file: Unexpected contents. "
-                    f"Skipping {file_path}."
-                )
-                e.args += (msg,)
-                log.exception(e)
+            # should be true in any case, since this has been dispatched here
+            # so simply skip
+            line = next(reader)
+            #assert line[0] == "Disclaimer: All data is without guarantee, errors and changes are reserved."
+
+            # for transactions, it's currently written "id" (small)
+            line = next(reader)
+            if line[0].startswith("Account id :"):
+                log.warning(f"{file_path} looks like a Bitpanda transaction file. Skipping.")
                 return
+
+            assert line[0].startswith("Account ID:")
             line = next(reader)
             # empty line - still keep this check in case Bitpanda changes the transaction file to match the
             # trade header (casing)

--- a/src/book.py
+++ b/src/book.py
@@ -365,7 +365,7 @@ class Book:
 
     def _read_bitpanda_pro_trades(self, file_path: Path) -> None:
         """
-        Read trade statement from Bitpanda Pro
+        Read trade statement from Bitpanda Pro.
         """
 
         platform = "bitpanda_pro"
@@ -421,16 +421,28 @@ class Book:
 
                 # trade pair is of form e.g. BTC_EUR
                 assert [amount_currency, price_currency] == trade_pair.split("_")
+                # there shouldn't be any other types
+                assert operation == "BUY" or operation == "SELL"
 
                 coin = amount_currency
+                # always positive, regardless whether BUY or SELL
                 change = misc.force_decimal(amount)
+                # just to make sure it doesn't get changed some day
+                assert change > 0
+
+                # Add the BUY or SELL operation
                 self.append_operation(operation.title(), utc_time, platform, change, coin, row, file_path)
 
                 # only this is supported for now
+                # this is because _get_price_bitpanda_pro also needs to handle
+                # the foreign pairs
                 assert price_currency == "EUR"
+
                 # Save price in our local database for later.
                 price = misc.force_decimal(_price)
                 self.price_data.set_price_db(platform, coin, "EUR", utc_time, price)
+
+                # sanity checks
                 assert fee_currency == "BEST" or (
                     operation == "SELL" and fee_currency == price_currency) or (
                     operation == "BUY" and fee_currency == amount_currency)

--- a/src/book.py
+++ b/src/book.py
@@ -364,8 +364,10 @@ class Book:
         self._read_kraken_ledgers(file_path)
 
     def _read_bitpanda_pro_trades(self, file_path: Path) -> None:
-        """
-        Read trade statement from Bitpanda Pro.
+        """Reads a trade statement from Bitpanda Pro.
+
+        Args:
+            file_path (Path): Path to Bitpanda trade history.
         """
 
         platform = "bitpanda_pro"

--- a/src/book.py
+++ b/src/book.py
@@ -430,23 +430,19 @@ class Book:
                 assert price_currency == "EUR"
                 # Save price in our local database for later.
                 self.price_data.set_price_db(platform, coin, "EUR", utc_time, price)
+                assert fee_currency == "BEST" or (
+                    operation == "SELL" and fee_currency == price_currency) or (
+                    operation == "BUY" and fee_currency == amount_currency)
 
+                # TODO: Need getpricedata for BEST
+                if fee_currency != "BEST":
+                    self.append_operation(
+                        "Fee", utc_time, platform,  misc.force_decimal(fee), fee_currency, row, file_path
+                    )
                 pass
                 # self.append_operation(
                 #     operation, utc_time, platform, change, coin, row, file_path
-                # )
-
-
-                # if operation == "Sell":
-                #     assert isinstance(eur_subtotal, decimal.Decimal)
-                #     self.append_operation(
-                #         "Buy", utc_time, platform, eur_subtotal, "EUR", row, file_path
-                #     )
-                # elif operation == "Buy":
-                #     assert isinstance(eur_subtotal, decimal.Decimal)
-                #     self.append_operation(
-                #         "Sell", utc_time, platform, eur_subtotal, "EUR", row, file_path
-                #     )
+                #
 
                 # if eur_fee:
                 #     self.append_operation(

--- a/src/book.py
+++ b/src/book.py
@@ -374,18 +374,19 @@ class Book:
         with open(file_path, encoding="utf8") as f:
             reader = csv.reader(f)
 
-            # should be true in any case, since this has been dispatched here
-            # so simply skip
+            # skip header
             line = next(reader)
-            # assert line[0] == \
-            # "Disclaimer: ..."
+
+            line = next(reader)
+
+            transaction_file_warn = (
+                f"{file_path} looks like a Bitpanda transaction file."
+                " Skipping. Please download the trade history instead."
+            )
 
             # for transactions, it's currently written "id" (small)
-            line = next(reader)
             if line[0].startswith("Account id :"):
-                log.warning(
-                    f"{file_path} looks like a Bitpanda transaction file. Skipping."
-                )
+                log.warning(transaction_file_warn)
                 return
 
             assert line[0].startswith("Account ID:")
@@ -393,10 +394,9 @@ class Book:
             # empty line - still keep this check in case Bitpanda changes the
             # transaction file to match the trade header (casing)
             if not line:
-                log.warning(
-                    f"{file_path} looks like a Bitpanda transaction file. Skipping."
-                )
+                log.warning(transaction_file_warn)
                 return
+
             elif line[0] != "Bitpanda Pro trade history":
                 log.warning(
                     f"{file_path} doesn't look like a Bitpanda trade file. Skipping."
@@ -432,38 +432,22 @@ class Book:
                 _utc_time,
             ) in reader:
                 row = reader.line_num
-                # make RFC3339 timestamp ISO 8601 parseable
-                if _utc_time[-1] == "Z":
-                    _utc_time = _utc_time[:-1] + "+00:00"
-
-                utc_time = datetime.datetime.fromisoformat(_utc_time)
-                # not needed, already taken care of
-                # utc_time = utc_time.replace(tzinfo=datetime.timezone.utc)
 
                 # trade pair is of form e.g. BTC_EUR
                 assert [amount_currency, price_currency] == trade_pair.split("_")
-                # there shouldn't be any other types
-                assert operation == "BUY" or operation == "SELL"
 
-                coin = amount_currency
-                # always positive, regardless whether BUY or SELL
+                # At the time of writing (2021-05-02),
+                # there were only these two operations
+                assert operation in ["BUY", "SELL"], "Unsupported operation"
+
                 change = misc.force_decimal(amount)
-                # just to make sure it doesn't get changed some day
-                assert change > 0
+                assert change > 0, "Unexpected value for 'Amount' column"
 
-                # Add the BUY or SELL operation
-                self.append_operation(
-                    operation.title(), utc_time, platform, change, coin, row, file_path
+                # see _get_price_bitpanda_pro in price_data.py
+                assert price_currency == "EUR", (
+                    "Only Euro is supported as 'price' currency, "
+                    "since price fetching is not fully implemented yet."
                 )
-
-                # only this is supported for now
-                # this is because _get_price_bitpanda_pro also needs to handle
-                # the foreign pairs
-                assert price_currency == "EUR"
-
-                # Save price in our local database for later.
-                price = misc.force_decimal(_price)
-                self.price_data.set_price_db(platform, coin, "EUR", utc_time, price)
 
                 # sanity checks
                 assert (
@@ -471,6 +455,23 @@ class Book:
                     or (operation == "SELL" and fee_currency == price_currency)
                     or (operation == "BUY" and fee_currency == amount_currency)
                 )
+
+                # make RFC3339 timestamp ISO 8601 parseable
+                if _utc_time[-1] == "Z":
+                    _utc_time = _utc_time[:-1] + "+00:00"
+
+                # timezone information is already taken care of with this
+                utc_time = datetime.datetime.fromisoformat(_utc_time)
+
+                coin = amount_currency
+
+                self.append_operation(
+                    operation.title(), utc_time, platform, change, coin, row, file_path
+                )
+
+                # Save price in our local database for later.
+                price = misc.force_decimal(_price)
+                self.price_data.set_price_db(platform, coin, "EUR", utc_time, price)
 
                 self.append_operation(
                     "Fee",

--- a/src/book.py
+++ b/src/book.py
@@ -382,8 +382,7 @@ class Book:
             line = next(reader)
             if line[0].startswith("Account id :"):
                 log.warning(
-                    f"{file_path} looks like a Bitpanda transaction file."
-                    " Skipping."
+                    f"{file_path} looks like a Bitpanda transaction file. Skipping."
                 )
                 return
 
@@ -404,8 +403,17 @@ class Book:
 
             line = next(reader)
             assert line == [
-                "Order ID", "Trade ID", "Type", "Market", "Amount", "Amount Currency",
-                "Price", "Price Currency", "Fee", "Fee Currency", "Time (UTC)"
+                "Order ID",
+                "Trade ID",
+                "Type",
+                "Market",
+                "Amount",
+                "Amount Currency",
+                "Price",
+                "Price Currency",
+                "Fee",
+                "Fee Currency",
+                "Time (UTC)",
             ]
 
             for (
@@ -419,7 +427,7 @@ class Book:
                 price_currency,
                 fee,
                 fee_currency,
-                _utc_time
+                _utc_time,
             ) in reader:
                 row = reader.line_num
                 # make RFC3339 timestamp ISO 8601 parseable
@@ -443,13 +451,7 @@ class Book:
 
                 # Add the BUY or SELL operation
                 self.append_operation(
-                    operation.title(),
-                    utc_time,
-                    platform,
-                    change,
-                    coin,
-                    row,
-                    file_path
+                    operation.title(), utc_time, platform, change, coin, row, file_path
                 )
 
                 # only this is supported for now
@@ -462,9 +464,11 @@ class Book:
                 self.price_data.set_price_db(platform, coin, "EUR", utc_time, price)
 
                 # sanity checks
-                assert fee_currency == "BEST" or (
-                    operation == "SELL" and fee_currency == price_currency) or (
-                    operation == "BUY" and fee_currency == amount_currency)
+                assert (
+                    fee_currency == "BEST"
+                    or (operation == "SELL" and fee_currency == price_currency)
+                    or (operation == "BUY" and fee_currency == amount_currency)
+                )
 
                 self.append_operation(
                     "Fee",
@@ -473,7 +477,7 @@ class Book:
                     misc.force_decimal(fee),
                     fee_currency,
                     row,
-                    file_path
+                    file_path,
                 )
 
     def detect_exchange(self, file_path: Path) -> Optional[str]:
@@ -539,7 +543,7 @@ class Book:
                 "bitpanda_pro_trades": [
                     "Disclaimer: All data is without guarantee,"
                     " errors and changes are reserved."
-                ]
+                ],
             }
             for exchange, expected in expected_headers.items():
                 if header == expected:

--- a/src/book.py
+++ b/src/book.py
@@ -404,7 +404,7 @@ class Book:
                 trade_pair,
                 amount,
                 amount_currency,
-                price,
+                _price,
                 price_currency,
                 fee,
                 fee_currency,
@@ -429,6 +429,7 @@ class Book:
                 # only this is supported for now
                 assert price_currency == "EUR"
                 # Save price in our local database for later.
+                price = misc.force_decimal(_price)
                 self.price_data.set_price_db(platform, coin, "EUR", utc_time, price)
                 assert fee_currency == "BEST" or (
                     operation == "SELL" and fee_currency == price_currency) or (

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -151,9 +151,9 @@ class PriceData:
         Currently, only BEST_EUR is tested.
         """
 
-        # other combination should not occur, since I enter them within the trade
-        # other pairs need to be tested. Also, they might need different behavior, if there isn't a
-        # matching endpoint
+        # other combination should not occur, since I enter them within thetrade
+        # other pairs need to be tested. Also, they might need different behavior,
+        # if there isn't a matching endpoint
         assert base_asset == "BEST" and quote_asset == "EUR"
         baseurl = "https://api.exchange.bitpanda.com/public/v1/candlesticks/BEST_EUR"
 
@@ -166,7 +166,12 @@ class PriceData:
         for t in timeframes:
             end = utc_time
             begin = utc_time - datetime.timedelta(minutes=t)
-            params = {"unit": "MINUTES", "period": t, "from": begin.isoformat(), "to": end.isoformat()}
+            params = {
+                "unit": "MINUTES",
+                "period": t,
+                "from": begin.isoformat(),
+                "to": end.isoformat()
+            }
             r = requests.get(baseurl, params=params)
 
             assert r.status_code == 200
@@ -177,11 +182,14 @@ class PriceData:
 
         # if we didn't get data for the 30 minute frame, give up?
         assert data
-        # There actually shouldn't be more than one entry if period and granularity are the same?
+        # There actually shouldn't be more than one entry if period and granularity are
+        # the same?
         assert len(data) == 1
 
         # simply take the average
-        return (misc.force_decimal(data[0]["high"]) + misc.force_decimal(data[0]["low"])) / 2
+        high = misc.force_decimal(data[0]["high"])
+        low = misc.force_decimal(data[0]["low"])
+        return (high + low) / 2
 
     @misc.delayed
     def _get_price_kraken(

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -22,7 +22,7 @@ import logging
 import sqlite3
 import time
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import requests
 
@@ -163,7 +163,9 @@ class PriceData:
         for t in timeframes:
             end = utc_time
             begin = utc_time - datetime.timedelta(minutes=t)
-            params = {
+
+            # https://github.com/python/mypy/issues/3176
+            params: Dict[str, Union[int, str]] = {
                 "unit": "MINUTES",
                 "period": t,
                 "from": begin.isoformat(),

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -146,15 +146,23 @@ class PriceData:
         This uses the "candlestricks" API endpoint.
         It returns the highest and lowest price for the COIN in a given time frame.
 
-        Currently, only BEST_EUR is supported.
+        Timeframe ends at the requested time.
+
+        Currently, only BEST_EUR is tested.
         """
 
         # other combination should not occur, since I enter them within the trade
+        # other pairs need to be tested. Also, they might need different behavior, if there isn't a
+        # matching endpoint
         assert base_asset == "BEST" and quote_asset == "EUR"
         baseurl = "https://api.exchange.bitpanda.com/public/v1/candlesticks/BEST_EUR"
 
+        # Bitpanda Pro only supports distinctive arguments for this, *not arbitrary*
         timeframes = [1, 5, 15, 30]
 
+        # get the smallest timeframe possible
+        # if there were no trades in the requested time frame, the
+        # returned data will be empty
         for t in timeframes:
             end = utc_time
             begin = utc_time - datetime.timedelta(minutes=t)

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -22,7 +22,7 @@ import logging
 import sqlite3
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import requests
 
@@ -155,7 +155,7 @@ class PriceData:
             decimal.Decimal: Price of the asset pair.
         """
 
-        # other combination should not occur, since I enter them within thetrade
+        # other combination should not occur, since I enter them within the trade
         # other pairs need to be tested. Also, they might need different behavior,
         # if there isn't a matching endpoint
         assert base_asset == "BEST" and quote_asset == "EUR"
@@ -172,7 +172,7 @@ class PriceData:
             begin = utc_time - datetime.timedelta(minutes=t)
 
             # https://github.com/python/mypy/issues/3176
-            params: Dict[str, Union[int, str]] = {
+            params: dict[str, Union[int, str]] = {
                 "unit": "MINUTES",
                 "period": t,
                 "from": begin.isoformat(),

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -137,8 +137,7 @@ class PriceData:
     def _get_price_bitpanda_pro(
         self, base_asset: str, utc_time: datetime.datetime, quote_asset: str
     ) -> decimal.Decimal:
-        """
-        Retrieve the price from the Bitpanda Pro API.
+        """Retrieve the price from the Bitpanda Pro API.
 
         This uses the "candlestricks" API endpoint.
         It returns the highest and lowest price for the COIN in a given time frame.
@@ -146,6 +145,14 @@ class PriceData:
         Timeframe ends at the requested time.
 
         Currently, only BEST_EUR is tested.
+
+        Args:
+            base_asset (str): The currency to get the price for.
+            utc_time (datetime.datetime): Time of the trade to fetch the price for.
+            quote_asset (str): The currency for the price.
+
+        Returns:
+            decimal.Decimal: Price of the asset pair.
         """
 
         # other combination should not occur, since I enter them within thetrade

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -135,10 +135,7 @@ class PriceData:
 
     @misc.delayed
     def _get_price_bitpanda_pro(
-        self,
-        base_asset: str,
-        utc_time: datetime.datetime,
-        quote_asset: str
+        self, base_asset: str, utc_time: datetime.datetime, quote_asset: str
     ) -> decimal.Decimal:
         """
         Retrieve the price from the Bitpanda Pro API.
@@ -170,7 +167,7 @@ class PriceData:
                 "unit": "MINUTES",
                 "period": t,
                 "from": begin.isoformat(),
-                "to": end.isoformat()
+                "to": end.isoformat(),
             }
             r = requests.get(baseurl, params=params)
 


### PR DESCRIPTION
This adds Bitpanda Pro as an exchange. Only trades are supported currently. No transactions (deposits/withdrawals).

The price data for the coins are taken from the trades themselves, with the exception of BEST - which is used for fee payment.

For fetching price data via REST API, only BEST_EUR is supported for now - which should suffice.

Issue #42 
