### PR TITLE
Add sell price to TaxEvent and thus also CSV export

### DIFF
--- a/src/taxman.py
+++ b/src/taxman.py
@@ -110,7 +110,7 @@ class Taxman:
                 if self.in_tax_year(op) and coin != config.FIAT:
                     taxation_type = "Sonstige Einkünfte"
                     # Price of the sell.
-                    total_win = self.price_data.get_cost(op)
+                    sell_price = self.price_data.get_cost(op)
                     taxed_gain = decimal.Decimal()
                     # Coins which are older than (in this case) one year or
                     # which come from an Airdrop, CoinLend or Commission (in an
@@ -130,8 +130,9 @@ class Taxman:
                             )
                             and not sc.op.coin == config.FIAT
                         ):
-                            partial_win = (sc.sold / op.change) * total_win
-                            taxed_gain += partial_win - self.price_data.get_cost(sc)
+                            partial_sell_price = (sc.sold / op.change) * sell_price
+                            sold_coin_cost = self.price_data.get_cost(sc)
+                            taxed_gain += partial_sell_price - sold_coin_cost
                     remark = ", ".join(
                         f"{sc.sold} from {sc.op.utc_time} "
                         f"({sc.op.__class__.__name__})"
@@ -141,8 +142,7 @@ class Taxman:
                         taxation_type,
                         taxed_gain,
                         op,
-                        total_win,
-                        total_win - taxed_gain,
+                        sell_price,
                         remark,
                     )
                     self.tax_events.append(tx)
@@ -242,7 +242,6 @@ class Taxman:
                 "Action",
                 "Amount",
                 "Asset",
-                f"Buy Price in {config.FIAT}",
                 f"Sell Price in {config.FIAT}",
                 "Remark",
             ]
@@ -256,7 +255,6 @@ class Taxman:
                     tx.op.__class__.__name__,
                     tx.op.change,
                     tx.op.coin,
-                    tx.buy_price,
                     tx.sell_price,
                     tx.remark,
                 ]

--- a/src/taxman.py
+++ b/src/taxman.py
@@ -137,7 +137,14 @@ class Taxman:
                         f"({sc.op.__class__.__name__})"
                         for sc in sold_coins
                     )
-                    tx = transaction.TaxEvent(taxation_type, taxed_gain, op, remark)
+                    tx = transaction.TaxEvent(
+                        taxation_type,
+                        taxed_gain,
+                        op,
+                        total_win,
+                        total_win - taxed_gain,
+                        remark,
+                    )
                     self.tax_events.append(tx)
             elif isinstance(
                 op, (transaction.CoinLendInterest, transaction.StakingInterest)
@@ -235,6 +242,8 @@ class Taxman:
                 "Action",
                 "Amount",
                 "Asset",
+                f"Buy Price in {config.FIAT}",
+                f"Sell Price in {config.FIAT}",
                 "Remark",
             ]
             writer.writerow(header)
@@ -247,6 +256,8 @@ class Taxman:
                     tx.op.__class__.__name__,
                     tx.op.change,
                     tx.op.coin,
+                    tx.buy_price,
+                    tx.sell_price,
                     tx.remark,
                 ]
                 writer.writerow(line)

--- a/src/transaction.py
+++ b/src/transaction.py
@@ -129,4 +129,6 @@ class TaxEvent:
     taxation_type: str
     taxed_gain: decimal.Decimal
     op: Operation
+    buy_price: decimal.Decimal = decimal.Decimal()
+    sell_price: decimal.Decimal = decimal.Decimal()
     remark: str = ""

--- a/src/transaction.py
+++ b/src/transaction.py
@@ -129,6 +129,5 @@ class TaxEvent:
     taxation_type: str
     taxed_gain: decimal.Decimal
     op: Operation
-    buy_price: decimal.Decimal = decimal.Decimal()
     sell_price: decimal.Decimal = decimal.Decimal()
     remark: str = ""


### PR DESCRIPTION
This PR adds two new columns to the exported CSV:
* ~Buy Price in {FIAT}~
* Sell Price in {FIAT}

The reason was that I needed to add these values to my taxation software and it wasn't possible to calculate either from the data already available in the CSV.

~The data is a bit redundant because the "taxed gain" is the difference between both new columns, so only one new column would be required to do your own maths in the spreadsheet application of your choice. However I thought it would be helpful to have both and avoid as much content transformation as possible.~

Let me know what you think of this change and whether it's okay to "break" the existing format. Perhaps it would make sense to add the amount of fees as the "Sell price" and leave "Buy price" as 0, but it might also confuse people.

In the long term, we might also think about having different formats which can be used for exporting. E.g. CoinTracking has its own format, which is supported by WISO software (see https://cointracking.info/tax/tax_details/WISO.php?tax=foobar ) - probably other taxation softwares already have or will have something similar in the future.


Update 2021-05-10: initially the "buy price" was also part of this PR. I removed it and also updated this comment to avoid further confusion.