### PR TITLE
add liquid swap

### DIFF
--- a/src/book.py
+++ b/src/book.py
@@ -78,6 +78,8 @@ class Book:
             "Launchpool Interest": "StakingInterest",
             "Cash Voucher distribution": "Airdrop",
             "Super BNB Mining": "StakingInterest",
+            "Liquid Swap add": "CoinLend",
+            "Liquid Swap remove": "CoinLendEnd",
         }
 
         with open(file_path, encoding="utf8") as f:


### PR DESCRIPTION
closes #51 
does not add support for defi lending  only for liquid swap this should maybe be another issue

also currently binance classifies the rewards as "distribution" and we therefore as airdrop which im not quite sure is correct, the same goes for eth2 staking