### PR TITLE
Add usdt-retry when binance provides no price for btc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ clean:
 
 cleanrun: clean run
 
+check-db:
+	cd src && python -c 'from price_data import PriceData; PriceData().check_database()'
+
 # Install requirements
 install:
 	python -m pip install --upgrade pip
@@ -40,4 +43,4 @@ venv:
 	python -m venv .pyenv
 	.pyenv\Scripts\activate && make install	
 
-.PHONY: flake8 mypy check-isort lint isort black format run clean cleanrun install venv
+.PHONY: flake8 mypy check-isort lint isort black format run clean cleanrun check-db install venv

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -122,9 +122,10 @@ class PriceData:
             log.warning("Binance offers no price for `%s` at %s", symbol, utc_time)
             if quote_asset == "USDT":
                 return decimal.Decimal()
-            log.warning(f"Trying {base_asset}USDT and {quote_asset}USDT")
+            log.info(f"Trying {base_asset}USDT and {quote_asset}USDT")
+            if quote := self.get_price("binance", quote_asset, utc_time, "USDT") == 0.0:
+                return quote
             usdt = self.get_price("binance", base_asset, utc_time, "USDT")
-            quote = self.get_price("binance", quote_asset, utc_time, "USDT")
             return usdt / quote
 
         # Calculate average price.
@@ -569,13 +570,13 @@ class PriceData:
             return price * tr.sold
         raise NotImplementedError
 
-    def check_database(
-        self,
-    ):
+    def check_database(self):
+        stats = {}
+
         for db_path in Path(config.DATA_PATH).glob("*.db"):
             if db_path.is_file():
                 platform = db_path.stem
-
+                stats[platform] = {"fix": 0, "rem": 0}
                 try:
                     get_price = getattr(self, f"_get_price_{platform}")
                 except AttributeError:
@@ -587,12 +588,11 @@ class PriceData:
                         )
 
                 with sqlite3.connect(db_path) as conn:
-                    query = "SELECT name FROM sqlite_master where type='table'"
+                    query = f"SELECT name FROM sqlite_master where type='table' AND name LIKE '%{config.FIAT_CLASS.name}'"
                     cur = conn.execute(query)
-
-                    for table in cur.fetchall():
-                        tablename = table[0]
-                        pair = tablename.split("/")
+                    tablenames = (result[0] for result in cur.fetchall())
+                    for tablename in tablenames:
+                        base_asset, quote_asset = tablename.split("/")
                         query = f"SELECT utc_time FROM `{tablename}` WHERE price<=0.0;"
                         cur = conn.execute(query)
 
@@ -600,13 +600,24 @@ class PriceData:
                             utc_time = datetime.datetime.strptime(
                                 row[0], "%Y-%m-%d %H:%M:%S%z"
                             )
-                            price = get_price(pair[0], utc_time, pair[1])
-                            log.warning(
-                                f"Updating {tablename} at {utc_time} to {price}"
-                            )
-                            query = (
-                                f"UPDATE `{tablename}` SET price=? WHERE utc_time=?;"
-                            )
+                            price = get_price(base_asset, utc_time, quote_asset)
 
-                            conn.execute(query, (str(price), utc_time))
-                            conn.commit()
+                            if price == 0.0:
+                                log.warning(
+                                    f"Could not fetch price for pair {tablename} on {platform} at {utc_time}"
+                                )
+                                stats[platform]["rem"] += 1
+                            else:
+                                log.info(
+                                    f"Updating {tablename} at {utc_time} to {price}"
+                                )
+                                query = f"UPDATE `{tablename}` SET price=? WHERE utc_time=?;"
+                                conn.execute(query, (str(price), utc_time))
+                                stats[platform]["fix"] += 1
+
+                    conn.commit()
+
+        log.info("Check Database Result:")
+        for platform, result in stats.items():
+            fixed, remaining = result.values()
+            log.info(f"{platform}:\nFixed: {fixed}, Remaining: {remaining}")

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -596,11 +596,7 @@ class PriceData:
                         )
 
                 with sqlite3.connect(db_path) as conn:
-                    query = f"""
-                    SELECT name FROM sqlite_master
-                    WHERE type='table'
-                    AND name LIKE '%{config.FIAT_CLASS.name}'
-                    """
+                    query = "SELECT name FROM sqlite_master WHERE type='table'"
                     cur = conn.execute(query)
                     tablenames = (result[0] for result in cur.fetchall())
                     for tablename in tablenames:

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -120,13 +120,11 @@ class PriceData:
 
         if len(data) == 0:
             log.warning(
-                f"""
-            Binance offers no price
-            for {symbol} at {utc_time}
-            Retrying with {base_asset}USDT and {quote_asset}USDT
-            """,
+                "Binance offers no price for %s at %s. Trying %s/USDT and %s/USDT",
                 symbol,
                 utc_time,
+                base_asset,
+                quote_asset,
             )
             if quote_asset == "USDT":
                 return decimal.Decimal()
@@ -634,4 +632,4 @@ class PriceData:
         log.info("Check Database Result:")
         for platform, result in stats.items():
             fixed, remaining = result.values()
-            log.info(f"{platform}:\nFixed: {fixed}, Remaining: {remaining}")
+            log.info(f"{platform}: {fixed} fixed, {remaining} remaining")


### PR DESCRIPTION
When no price data is provided (price == 0.0 in db) for COIN/BTC this pr uses a fallback to USDT.
`make check-db` will check the database for 0.0-prices and tries to fix them with real data.

In my specific case I could fetch prices for all but one singe entry in the db.

