### PR TITLE
Support "new" Bitpanda Pro CSV export format

### DIFF
--- a/src/book.py
+++ b/src/book.py
@@ -575,25 +575,40 @@ class Book:
                 "BEST_EUR Rate",
             ]
 
-            for (
-                _order_id,
-                _trace_id,
-                operation,
-                trade_pair,
-                amount,
-                amount_currency,
-                _price,
-                price_currency,
-                fee,
-                fee_currency,
-                *rest_col,
-            ) in reader:
-                assert len(rest_col) in [1, 2], "Something is wrong with the CSV"
-                _utc_time = rest_col[0]
-                if len(rest_col) == 1:
+            for current_line in reader:
+                if len(current_line) == 11:
+                    (
+                        _order_id,
+                        _trace_id,
+                        operation,
+                        trade_pair,
+                        amount,
+                        amount_currency,
+                        _price,
+                        price_currency,
+                        fee,
+                        fee_currency,
+                        _utc_time,
+                    ) = current_line
                     best_price = None
-                elif len(rest_col) == 2:
-                    best_price = rest_col[1]
+                elif len(current_line) == 12:
+                    (
+                        _order_id,
+                        _trace_id,
+                        operation,
+                        trade_pair,
+                        amount,
+                        amount_currency,
+                        _price,
+                        price_currency,
+                        fee,
+                        fee_currency,
+                        _utc_time,
+                        best_price,
+                    ) = current_line
+                else:
+                    raise NotImplementedError
+
                 row = reader.line_num
 
                 # trade pair is of form e.g. BTC_EUR

--- a/src/book.py
+++ b/src/book.py
@@ -549,9 +549,30 @@ class Book:
 
             line = next(reader)
             assert line == [
-                "Order ID","Trade ID","Type","Market","Amount","Amount Currency","Price","Price Currency","Fee","Fee Currency","Time (UTC)",
+                "Order ID",
+                "Trade ID",
+                "Type",
+                "Market",
+                "Amount",
+                "Amount Currency",
+                "Price",
+                "Price Currency",
+                "Fee",
+                "Fee Currency",
+                "Time (UTC)",
             ] or line == [
-                "Order ID","Trade ID","Type","Market","Amount","Amount Currency","Price","Price Currency","Fee","Fee Currency","Time (UTC)","BEST_EUR Rate"
+                "Order ID",
+                "Trade ID",
+                "Type",
+                "Market",
+                "Amount",
+                "Amount Currency",
+                "Price",
+                "Price Currency",
+                "Fee",
+                "Fee Currency",
+                "Time (UTC)",
+                "BEST_EUR Rate",
             ]
 
             for (
@@ -567,7 +588,7 @@ class Book:
                 fee_currency,
                 *rest_col,
             ) in reader:
-                assert len(rest_col) in [1,2], "Something is wrong with the CSV"
+                assert len(rest_col) in [1, 2], "Something is wrong with the CSV"
                 _utc_time = rest_col[0]
                 if len(rest_col) == 1:
                     best_price = None
@@ -610,7 +631,13 @@ class Book:
                 price = misc.force_decimal(_price)
                 self.price_data.set_price_db(platform, coin, "EUR", utc_time, price)
                 if best_price:
-                    self.price_data.set_price_db(platform, "BEST", "EUR", utc_time, misc.force_decimal(best_price))
+                    self.price_data.set_price_db(
+                        platform,
+                        "BEST",
+                        "EUR",
+                        utc_time,
+                        misc.force_decimal(best_price),
+                    )
 
                 self.append_operation(
                     "Fee",

--- a/src/book.py
+++ b/src/book.py
@@ -598,7 +598,7 @@ class Book:
                     fee_currency == "BEST"
                     or (operation == "SELL" and fee_currency == price_currency)
                     or (operation == "BUY" and fee_currency == amount_currency)
-                )
+                ), "Invalid fee currency"
 
                 utc_time = misc.parse_iso_timestamp(_utc_time)
 

--- a/src/book.py
+++ b/src/book.py
@@ -549,17 +549,9 @@ class Book:
 
             line = next(reader)
             assert line == [
-                "Order ID",
-                "Trade ID",
-                "Type",
-                "Market",
-                "Amount",
-                "Amount Currency",
-                "Price",
-                "Price Currency",
-                "Fee",
-                "Fee Currency",
-                "Time (UTC)",
+                "Order ID","Trade ID","Type","Market","Amount","Amount Currency","Price","Price Currency","Fee","Fee Currency","Time (UTC)",
+            ] or line == [
+                "Order ID","Trade ID","Type","Market","Amount","Amount Currency","Price","Price Currency","Fee","Fee Currency","Time (UTC)","BEST_EUR Rate"
             ]
 
             for (
@@ -573,8 +565,14 @@ class Book:
                 price_currency,
                 fee,
                 fee_currency,
-                _utc_time,
+                *rest_col,
             ) in reader:
+                assert len(rest_col) in [1,2], "Something is wrong with the CSV"
+                _utc_time = rest_col[0]
+                if len(rest_col) == 1:
+                    best_price = None
+                elif len(rest_col) == 2:
+                    best_price = rest_col[1]
                 row = reader.line_num
 
                 # trade pair is of form e.g. BTC_EUR
@@ -611,6 +609,8 @@ class Book:
                 # Save price in our local database for later.
                 price = misc.force_decimal(_price)
                 self.price_data.set_price_db(platform, coin, "EUR", utc_time, price)
+                if best_price:
+                    self.price_data.set_price_db(platform, "BEST", "EUR", utc_time, misc.force_decimal(best_price))
 
                 self.append_operation(
                     "Fee",

--- a/src/book.py
+++ b/src/book.py
@@ -548,31 +548,34 @@ class Book:
                 return
 
             line = next(reader)
-            assert line == [
-                "Order ID",
-                "Trade ID",
-                "Type",
-                "Market",
-                "Amount",
-                "Amount Currency",
-                "Price",
-                "Price Currency",
-                "Fee",
-                "Fee Currency",
-                "Time (UTC)",
-            ] or line == [
-                "Order ID",
-                "Trade ID",
-                "Type",
-                "Market",
-                "Amount",
-                "Amount Currency",
-                "Price",
-                "Price Currency",
-                "Fee",
-                "Fee Currency",
-                "Time (UTC)",
-                "BEST_EUR Rate",
+            assert line in [
+                [
+                    "Order ID",
+                    "Trade ID",
+                    "Type",
+                    "Market",
+                    "Amount",
+                    "Amount Currency",
+                    "Price",
+                    "Price Currency",
+                    "Fee",
+                    "Fee Currency",
+                    "Time (UTC)",
+                ],
+                [
+                    "Order ID",
+                    "Trade ID",
+                    "Type",
+                    "Market",
+                    "Amount",
+                    "Amount Currency",
+                    "Price",
+                    "Price Currency",
+                    "Fee",
+                    "Fee Currency",
+                    "Time (UTC)",
+                    "BEST_EUR Rate",
+                ],
             ]
 
             for current_line in reader:

--- a/src/book.py
+++ b/src/book.py
@@ -600,12 +600,7 @@ class Book:
                     or (operation == "BUY" and fee_currency == amount_currency)
                 )
 
-                # make RFC3339 timestamp ISO 8601 parseable
-                if _utc_time[-1] == "Z":
-                    _utc_time = _utc_time[:-1] + "+00:00"
-
-                # timezone information is already taken care of with this
-                utc_time = datetime.datetime.fromisoformat(_utc_time)
+                utc_time = misc.parse_iso_timestamp(_utc_time)
 
                 coin = amount_currency
 

--- a/src/misc.py
+++ b/src/misc.py
@@ -140,9 +140,26 @@ def to_iso_timestamp(d: datetime.datetime) -> str:
         d (datetime.datetime)
 
     Returns:
-        str: ISI8601 timestamp.
+        str: ISO8601 timestamp.
     """
     return d.isoformat().replace("+00:00", "Z")
+
+
+def parse_iso_timestamp(d: str) -> datetime.datetime:
+    """Parse a ISO8601 timestamp, return a datetime object.
+
+    Args:
+        d (str) A string in ISO8601 format
+
+    Returns:
+        datetime.datetime: The datetime object representing the string.
+    """
+    # make RFC3339 timestamp ISO 8601 parseable
+    if d[-1] == "Z":
+        d = d[:-1] + "+00:00"
+
+    # timezone information is already taken care of with this
+    return datetime.datetime.fromisoformat(d)
 
 
 def group_by(lst: L, key: str) -> dict[str, L]:

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -292,6 +292,10 @@ class PriceData:
         # simply take the average
         high = misc.force_decimal(data[0]["high"])
         low = misc.force_decimal(data[0]["low"])
+
+        # if spread is greater than 3%
+        if (high - low) / high > 0.03:
+            log.warning(f"Price spread is greater than 3%! High: {high}, Low: {low}")
         return (high + low) / 2
 
     @misc.delayed


### PR DESCRIPTION
Bitpanda added a "BEST_EUR rate" column.

This PR handles the new format. - In a way so that the old format is still supported. It also moves date parsing into the misc module.

This solves #79 