### PR TITLE
Fix sort order of transactions

### DIFF
--- a/src/transaction.py
+++ b/src/transaction.py
@@ -183,6 +183,6 @@ def sort_operations(
             idx = operations_order.index(type(op))
         except ValueError:
             idx = 0
-        return tuple([idx] + [getattr(op, key) for key in keys] if keys else [])
+        return tuple(([getattr(op, key) for key in keys] if keys else []) + [idx])
 
     return sorted(operations, key=key)


### PR DESCRIPTION
Sort by date first, only then by operation

This should fix the sort order introduced in 41d4bd6

fixes #81