### PR TITLE
Detailed export

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -37,6 +37,8 @@ CALCULATE_VIRTUAL_SELL = True
 # taxable gains. Make sure, that this method is accepted by your tax
 # authority.
 MULTI_DEPOT = True
+# Export all events (True) or only taxable events (False)
+EXPORT_ALL_EVENTS = True
 
 # Read in environmental variables.
 if _env_country := environ.get("COUNTRY"):

--- a/src/config.py
+++ b/src/config.py
@@ -33,6 +33,8 @@ MEAN_MISSING_PRICES = False
 # Calculate the (taxed) gains, if the left over coins would be sold right now.
 # This will fetch the current prices and therefore slow down repetitive runs.
 CALCULATE_VIRTUAL_SELL = True
+# Include virtual sells in the export
+EXPORT_VIRTUAL_SELL = False
 # Evaluate taxes for each depot/platform separately. This may reduce your
 # taxable gains. Make sure, that this method is accepted by your tax
 # authority.

--- a/src/taxman.py
+++ b/src/taxman.py
@@ -207,7 +207,12 @@ class Taxman:
                         "Verkauf "
                         "(außerhalb des Steuerjahres oder steuerfrei)"
                     )
-                    tx = transaction.TaxEvent(taxation_type, decimal.Decimal(), op, False)
+                    tx = transaction.TaxEvent(
+                        taxation_type,
+                        decimal.Decimal(),
+                        op,
+                        False
+                    )
             elif isinstance(
                 op, (transaction.CoinLendInterest, transaction.StakingInterest)
             ):

--- a/src/taxman.py
+++ b/src/taxman.py
@@ -185,8 +185,8 @@ class Taxman:
                         config.FIAT
                     )
                     remark = (
-                        f"cost {cost} {config.FIAT}, "
-                        f"price {price} {config.FIAT}/{op.coin}"
+                        f"Kosten {cost} {config.FIAT}, "
+                        f"Preis {price} {config.FIAT}/{op.coin}"
                     )
                     tx = transaction.TaxEvent(
                         taxation_type,

--- a/src/taxman.py
+++ b/src/taxman.py
@@ -161,16 +161,16 @@ class Taxman:
                 tx = transaction.TaxEvent(taxation_type, taxed_gain, op, is_taxable)
             elif isinstance(op, transaction.CoinLend):
                 taxation_type = "CoinLend"
-                tx = transaction.TaxEvent(taxation_type, 0, op, False)
+                tx = transaction.TaxEvent(taxation_type, 0.0, op, False)
             elif isinstance(op, transaction.CoinLendEnd):
                 taxation_type = "CoinLendEnd"
-                tx = transaction.TaxEvent(taxation_type, 0, op, False)
+                tx = transaction.TaxEvent(taxation_type, 0.0, op, False)
             elif isinstance(op, transaction.Staking):
                 taxation_type = "Staking"
-                tx = transaction.TaxEvent(taxation_type, 0, op, False)
+                tx = transaction.TaxEvent(taxation_type, 0.0, op, False)
             elif isinstance(op, transaction.StakingEnd):
                 taxation_type = "StakingEnd"
-                tx = transaction.TaxEvent(taxation_type, 0, op, False)
+                tx = transaction.TaxEvent(taxation_type, 0.0, op, False)
             elif isinstance(op, transaction.Buy):
                 balance.put(op)
                 if misc.is_fiat(op.coin):
@@ -178,14 +178,33 @@ class Taxman:
                 else:
                     taxation_type = "Kauf"
                     cost = self.price_data.get_cost(op)
-                    price = self.price_data.get_price(op.platform, op.coin, op.utc_time, config.FIAT)
-                    remark = f"cost {cost} {config.FIAT}, price {price} {config.FIAT}/{op.coin}"
-                    tx = transaction.TaxEvent(taxation_type, 0, op, False, 0, 0, remark)     
+                    price = self.price_data.get_price(
+                        op.platform,
+                        op.coin,
+                        op.utc_time,
+                        config.FIAT
+                    )
+                    remark = (
+                        f"cost {cost} {config.FIAT}, "
+                        f"price {price} {config.FIAT}/{op.coin}"
+                    )
+                    tx = transaction.TaxEvent(
+                        taxation_type,
+                        0.0,
+                        op,
+                        False,
+                        0.0,
+                        0.0,
+                        remark
+                    )
             elif isinstance(op, transaction.Sell):
                 tx = evaluate_sell(op)
                 if not tx and not misc.is_fiat(op.coin):
-                    taxation_type = "Verkauf (außerhalb des Steuerjahres oder steuerfrei)"
-                    tx = transaction.TaxEvent(taxation_type, 0, op, False)
+                    taxation_type = (
+                        "Verkauf "
+                        "(außerhalb des Steuerjahres oder steuerfrei)"
+                    )
+                    tx = transaction.TaxEvent(taxation_type, 0.0, op, False)
             elif isinstance(
                 op, (transaction.CoinLendInterest, transaction.StakingInterest)
             ):
@@ -207,7 +226,7 @@ class Taxman:
             elif isinstance(op, transaction.Airdrop):
                 balance.put(op)
                 taxation_type = "Airdrop"
-                tx = transaction.TaxEvent(taxation_type, 0, op, False)
+                tx = transaction.TaxEvent(taxation_type, 0.0, op, False)
             elif isinstance(op, transaction.Commission):
                 balance.put(op)
                 taxation_type = "Einkünfte aus sonstigen Leistungen"
@@ -226,7 +245,7 @@ class Taxman:
                         "The evaluation might be wrong."
                     )
                 taxation_type = "Deposit"
-                tx = transaction.TaxEvent(taxation_type, 0, op, False)
+                tx = transaction.TaxEvent(taxation_type, 0.0, op, False)
             elif isinstance(op, transaction.Withdrawal):
                 if coin != config.FIAT:
                     log.warning(
@@ -235,7 +254,7 @@ class Taxman:
                         "The evaluation might be wrong."
                     )
                 taxation_type = "Withdrawal"
-                tx = transaction.TaxEvent(taxation_type, 0, op, False)
+                tx = transaction.TaxEvent(taxation_type, 0.0, op, False)
             else:
                 raise NotImplementedError
 

--- a/src/taxman.py
+++ b/src/taxman.py
@@ -103,7 +103,7 @@ class Taxman:
 
             taxation_type = "Sonstige Einkünfte"
             # Price of the sell.
-            sell_price = self.price_data.get_cost(op)
+            sell_value = self.price_data.get_cost(op)
             taxed_gain = decimal.Decimal()
             real_gain = decimal.Decimal()
             # Coins which are older than (in this case) one year or
@@ -126,9 +126,9 @@ class Taxman:
                 )
                 # Only calculate the gains if necessary.
                 if is_taxable or config.CALCULATE_VIRTUAL_SELL:
-                    partial_sell_price = (sc.sold / op.change) * sell_price
+                    partial_sell_value = (sc.sold / op.change) * sell_value
                     sold_coin_cost = self.price_data.get_cost(sc)
-                    gain = partial_sell_price - sold_coin_cost
+                    gain = partial_sell_value - sold_coin_cost
                     if is_taxable:
                         taxed_gain += gain
                     if config.CALCULATE_VIRTUAL_SELL:
@@ -142,7 +142,7 @@ class Taxman:
                 taxed_gain,
                 op,
                 is_taxable,
-                sell_price,
+                sell_value,
                 real_gain,
                 remark,
             )
@@ -343,12 +343,12 @@ class Taxman:
         # Summarize the virtual sell, if all left over coins would be sold right now.
         if self.virtual_tax_events:
             assert config.CALCULATE_VIRTUAL_SELL
-            invsted = sum(tx.sell_price for tx in self.virtual_tax_events)
+            invested = sum(tx.sell_value for tx in self.virtual_tax_events)
             real_gains = sum(tx.real_gain for tx in self.virtual_tax_events)
             taxed_gains = sum(tx.taxed_gain for tx in self.virtual_tax_events)
             print()
             print(
-                f"You are currently invested with {invsted:.2f} {config.FIAT}.\n"
+                f"You are currently invested with {invested:.2f} {config.FIAT}.\n"
                 f"If you would sell everything right now, "
                 f"you would realize {real_gains:.2f} {config.FIAT} gains "
                 f"({taxed_gains:.2f} {config.FIAT} taxed gain)."
@@ -357,13 +357,13 @@ class Taxman:
             print("Your current portfolio should be:")
             for tx in sorted(
                 self.virtual_tax_events,
-                key=lambda tx: tx.sell_price,
+                key=lambda tx: tx.sell_value,
                 reverse=True,
             ):
                 print(
                     f"{tx.op.platform}: "
                     f"{tx.op.change:.6f} {tx.op.coin} > "
-                    f"{tx.sell_price:.2f} {config.FIAT} "
+                    f"{tx.sell_value:.2f} {config.FIAT} "
                     f"({tx.real_gain:.2f} gain, {tx.taxed_gain:.2f} taxed gain)"
                 )
 
@@ -401,7 +401,7 @@ class Taxman:
                 "Action",
                 "Amount",
                 "Asset",
-                f"Sell Price in {config.FIAT}",
+                f"Sell Value in {config.FIAT}",
                 "Remark",
             ]
             writer.writerow(header)
@@ -415,7 +415,7 @@ class Taxman:
                     tx.op.__class__.__name__,
                     tx.op.change,
                     tx.op.coin,
-                    tx.sell_price,
+                    tx.sell_value,
                     tx.remark,
                 ]
                 if tx.is_taxable or config.EXPORT_ALL_EVENTS:

--- a/src/taxman.py
+++ b/src/taxman.py
@@ -134,7 +134,7 @@ class Taxman:
                     if config.CALCULATE_VIRTUAL_SELL:
                         real_gain += gain
             remark = ", ".join(
-                f"{sc.sold} from {sc.op.utc_time} " f"({sc.op.__class__.__name__})"
+                f"{sc.sold} von {sc.op.utc_time} " f"({sc.op.__class__.__name__})"
                 for sc in sold_coins
             )
             return transaction.TaxEvent(
@@ -367,7 +367,8 @@ class Taxman:
             writer.writerow(["# updated", datetime.date.today().strftime("%x")])
 
             header = [
-                "Date",
+                "Date and Time UTC",
+                "Platform",
                 "Taxation Type",
                 f"Taxed Gain in {config.FIAT}",
                 "Action",
@@ -380,7 +381,8 @@ class Taxman:
             # Tax events are currently sorted by coin. Sort by time instead.
             for tx in sorted(self.tax_events, key=lambda tx: tx.op.utc_time):
                 line = [
-                    tx.op.utc_time,
+                    tx.op.utc_time.strftime("%Y-%m-%d %H:%M:%S"),
+                    tx.op.platform,
                     tx.taxation_type,
                     tx.taxed_gain,
                     tx.op.__class__.__name__,

--- a/src/taxman.py
+++ b/src/taxman.py
@@ -405,6 +405,12 @@ class Taxman:
                 "Remark",
             ]
             writer.writerow(header)
+
+            if config.EXPORT_VIRTUAL_SELL:
+                # move virtual sells to tax_events list
+                self.tax_events = self.tax_events + self.virtual_tax_events
+                self.virtual_tax_events = []
+
             # Tax events are currently sorted by coin. Sort by time instead.
             for tx in sorted(self.tax_events, key=lambda tx: tx.op.utc_time):
                 line = [

--- a/src/transaction.py
+++ b/src/transaction.py
@@ -137,7 +137,7 @@ class TaxEvent:
     taxed_gain: decimal.Decimal
     op: Operation
     is_taxable: bool = True
-    sell_price: decimal.Decimal = decimal.Decimal()
+    sell_value: decimal.Decimal = decimal.Decimal()
     real_gain: decimal.Decimal = decimal.Decimal()
     remark: str = ""
 

--- a/src/transaction.py
+++ b/src/transaction.py
@@ -136,6 +136,7 @@ class TaxEvent:
     taxation_type: str
     taxed_gain: decimal.Decimal
     op: Operation
+    is_taxable: bool = True
     sell_price: decimal.Decimal = decimal.Decimal()
     real_gain: decimal.Decimal = decimal.Decimal()
     remark: str = ""


### PR DESCRIPTION
This is a draft for the detailed CSV export that contains all events (not only taxable ones).

@provinzio Thanks for your tips on how to approach this, they helped a lot.
As suggested, I added a boolean `is_taxable` to `TaxEvent`. Based on the new config setting `EXPORT_ALL_EVENTS`, either all or only taxable events are exported.
Additionally, with the new setting `EXPORT_VIRTUAL_SELL`, the virtual sells can also be exported to the CSV.

@scientes Tagging you since you were also interested in this feature.

Let me know what you think of it. Thanks! :)

Closes #94, closes #95