### PR TITLE
DB Hotfix

### DIFF
--- a/src/book.py
+++ b/src/book.py
@@ -783,7 +783,7 @@ class Book:
                 fiat,
                 amount_asset,
                 asset,
-                asset_price,
+                _asset_price,
                 asset_price_currency,
                 asset_class,
                 _product_id,

--- a/src/book.py
+++ b/src/book.py
@@ -272,8 +272,6 @@ class Book:
                 utc_time = utc_time.replace(tzinfo=datetime.timezone.utc)
                 operation = operation_mapping.get(operation, operation)
                 change = misc.force_decimal(_change)
-                #  Current price from exchange.
-                eur_spot = misc.force_decimal(_eur_spot)
                 #  Cost without fees.
                 eur_subtotal = misc.xdecimal(_eur_subtotal)
                 eur_fee = misc.xdecimal(_eur_fee)
@@ -283,9 +281,6 @@ class Book:
                 assert coin
                 assert change
                 assert _currency_spot == "EUR"
-
-                # Save price in our local database for later.
-                set_price_db(platform, coin, "EUR", utc_time, eur_spot)
 
                 if operation == "Convert":
                     # Parse change + coin from remark, which is
@@ -301,9 +296,6 @@ class Book:
                     convert_change = misc.force_decimal(_convert_change)
                     convert_coin = match.group("coin")
 
-                    eur_total = misc.force_decimal(_eur_total)
-                    convert_eur_spot = eur_total / convert_change
-
                     self.append_operation(
                         "Sell", utc_time, platform, change, coin, row, file_path
                     )
@@ -315,11 +307,6 @@ class Book:
                         convert_coin,
                         row,
                         file_path,
-                    )
-
-                    # Save convert price in local database, too.
-                    set_price_db(
-                        platform, convert_coin, "EUR", utc_time, convert_eur_spot
                     )
                 else:
                     self.append_operation(
@@ -861,9 +848,6 @@ class Book:
                         raise RuntimeError
                     change = misc.force_decimal(amount_asset)
                     change_fiat = misc.force_decimal(amount_fiat)
-                    # Save price in our local database for later.
-                    price = misc.force_decimal(asset_price)
-                    set_price_db(platform, asset, config.FIAT.upper(), utc_time, price)
 
                 if change < 0:
                     log.error(

--- a/src/database.py
+++ b/src/database.py
@@ -115,7 +115,8 @@ def get_price_db(
     else:
         return price
 
-def mean_price_db(
+
+def __mean_price_db(
     db_path: Path,
     tablename: str,
     utc_time: datetime.datetime,
@@ -182,6 +183,44 @@ def mean_price_db(
                 return price
 
     return decimal.Decimal()
+
+
+def mean_price_db(
+    platform: str,
+    coin: str,
+    reference_coin: str,
+    utc_time: datetime.datetime,
+    db_path: Optional[Path] = None,
+) -> decimal.Decimal:
+    """Try to retrieve the price right before and after `utc_time`
+    from our local database.
+
+    Return 0 if the price could not be estimated.
+    The function does not check, if a price for `utc_time` exists.
+
+    Args:
+        platform (str)
+        coin (str)
+        reference_coin (str)
+        utc_time (datetime.datetime)
+
+    Returns:
+        decimal.Decimal: Price.
+    """
+    coin_a, coin_b, inverted = _sort_pair(coin, reference_coin)
+    tablename = get_tablename(coin_a, coin_b)
+
+    if db_path is None and platform:
+        db_path = get_db_path(platform)
+
+    assert isinstance(db_path, Path), "DB path is no valid path"
+
+    price = __mean_price_db(db_path, tablename, utc_time)
+
+    if inverted:
+        return misc.reciprocal(price)
+    else:
+        return price
 
 
 def __delete_price_db(

--- a/src/database.py
+++ b/src/database.py
@@ -96,6 +96,7 @@ def get_price_db(
         coin (str)
         reference_coin (str)
         utc_time (datetime.datetime)
+        db_path (Optional[Path])
 
     Returns:
         Optional[decimal.Decimal]: Price.
@@ -205,6 +206,7 @@ def mean_price_db(
         coin (str)
         reference_coin (str)
         utc_time (datetime.datetime)
+        db_path (Optional[Path])
 
     Returns:
         decimal.Decimal: Price.
@@ -306,6 +308,8 @@ def set_price_db(
         reference_coin (str)
         utc_time (datetime.datetime)
         price (decimal.Decimal)
+        db_path (Optional[Path])
+        overwrite (bool)
     """
     assert coin != reference_coin
 

--- a/src/misc.py
+++ b/src/misc.py
@@ -48,31 +48,33 @@ def xfloat(x: Union[None, str, SupportsFloat]) -> Optional[float]:
     return None if x is None or x == "" else float(x)
 
 
-def xdecimal(x: Union[None, str, int, float]) -> Optional[decimal.Decimal]:
+def xdecimal(
+    x: Union[None, str, int, float, decimal.Decimal]
+) -> Optional[decimal.Decimal]:
     """Convert to decimal, but make sure, that empty values return as None.
 
     Integer and floats are converted to strings first to receive
     "real" Decimal values.
 
     Args:
-        x (Union[None, str, int, float])
+        x (Union[None, str, int, float, decimal.Decimal])
 
     Returns:
         Optional[decimal.Decimal]
     """
     if isinstance(x, (int, float)):
         x = str(x)
-    assert x is None or isinstance(x, str)
+    assert x is None or isinstance(x, str) or isinstance(x, decimal.Decimal)
     return None if x is None or x == "" else decimal.Decimal(x)
 
 
-def force_decimal(x: Union[str, int, float]) -> decimal.Decimal:
+def force_decimal(x: Union[None, str, int, float, decimal.Decimal]) -> decimal.Decimal:
     """Convert to decimal, but make sure, that empty values raise an error.
 
     See `xdecimal` for further informations.
 
     Args:
-        x (Union[None, str, int, float])
+        x (Union[None, str, int, float, decimal.Decimal])
 
     Raises:
         ValueError: The given argument can not be parsed accordingly.

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -514,7 +514,7 @@ class PriceData:
             # The price is missing. Check for prices before and after the
             # transaction and estimate the price.
             # Do not save price in database.
-            price = mean_price_db(db_path, tablename, utc_time)
+            price = mean_price_db(platform, coin, reference_coin, utc_time)
 
         return price
 

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -153,6 +153,16 @@ class PriceData:
         return average_price
 
     @misc.delayed
+    def _get_price_coinbase(
+        self,
+        base_asset: str,
+        utc_time: datetime.datetime,
+        quote_asset: str,
+        minutes_step: int = 5,
+    ) -> decimal.Decimal:
+        return self._get_price_coinbase_pro(base_asset, utc_time, quote_asset, minutes_step)
+
+    @misc.delayed
     def _get_price_coinbase_pro(
         self,
         base_asset: str,

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -30,11 +30,7 @@ import log_config
 import misc
 import transaction
 from core import kraken_pair_map
-from database import (
-    get_price_db,
-    mean_price_db,
-    set_price_db,
-)
+from database import get_price_db, mean_price_db, set_price_db
 
 log = log_config.getLogger(__name__)
 
@@ -155,7 +151,9 @@ class PriceData:
         quote_asset: str,
         minutes_step: int = 5,
     ) -> decimal.Decimal:
-        return self._get_price_coinbase_pro(base_asset, utc_time, quote_asset, minutes_step)
+        return self._get_price_coinbase_pro(
+            base_asset, utc_time, quote_asset, minutes_step
+        )
 
     @misc.delayed
     def _get_price_coinbase_pro(
@@ -197,7 +195,6 @@ class PriceData:
             params = f"start={start}&end={end}&granularity=60"
             url = f"{root_url}/products/{pair}/candles?{params}"
 
-            log.debug("Calling %s", url)
             log.debug(
                 f"Querying Coinbase Pro candles for {pair} at {utc_time} "
                 f"(offset={minutes_offset}m): Calling %s",
@@ -507,7 +504,7 @@ class PriceData:
             price = get_price(coin, utc_time, reference_coin, **kwargs)
             assert isinstance(price, decimal.Decimal)
             set_price_db(
-                platform, coin, reference_coin, utc_time, price, db_path=db_path
+                platform, coin, reference_coin, utc_time, price
             )
 
         if config.MEAN_MISSING_PRICES and price <= 0.0:

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -31,9 +31,7 @@ import misc
 import transaction
 from core import kraken_pair_map
 from database import (
-    get_db_path,
     get_price_db,
-    get_tablename,
     mean_price_db,
     set_price_db,
 )
@@ -50,9 +48,6 @@ log = log_config.getLogger(__name__)
 class PriceData:
     def get_db_path(self, platform: str) -> Path:
         return Path(config.DATA_PATH, f"{platform}.db")
-
-    def get_tablename(self, coin: str, reference_coin: str) -> str:
-        return f"{coin}/{reference_coin}"
 
     @misc.delayed
     def _get_price_binance(
@@ -501,11 +496,8 @@ class PriceData:
         if coin == reference_coin:
             return decimal.Decimal("1")
 
-        db_path = get_db_path(platform)
-        tablename = get_tablename(coin, reference_coin)
-
         # Check if price exists already in our database.
-        if (price := get_price_db(db_path, tablename, utc_time)) is None:
+        if (price := get_price_db(platform, coin, reference_coin, utc_time)) is None:
             # Price doesn't exists. Fetch price from platform.
             try:
                 get_price = getattr(self, f"_get_price_{platform}")


### PR DESCRIPTION
This PR does the following things:
- ADD get_price_db function with automatic coin sorting -> tablenames were not sorted before in the get_price_db function
- ADD mean_price_db function with automatic coin sorting -> to be consistent with get_/set_price_db
- UPDATE warnings for existing DB prices -> readability and consistency of warnings
- REMOVE writing prices into database when parsing CSV files for Coinbase and Bitpanda (replaced by new get_price_from_csv) -> else there's constant overwriting of prices. There's still one set_price_db for Bitpanda Pro, but I'm not sure how "BEST" price is used there and I don't have any logs to test, so I'm keeping it.
- ADD function get_price_coinbase -> forward to Coinbase Pro API, required for e.g. virtual sells
- ADD additional types to xdecimal and force_decimal -> for fixing linter errors