### PR TITLE
Resolve Withdrawals/Deposits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 account_statements/*
 data/*
 export/*
+withdrawals_deposits/*
 
 # Development folder
 dev/

--- a/src/book.py
+++ b/src/book.py
@@ -1107,6 +1107,31 @@ class Book:
                     overwrite=True,
                 )
 
+    def resolve_deposits(self) -> bool:
+        """ Matches withdrawals and deposits
+
+        Returns:
+            bool: Return True if everything went as expected.
+        """
+        paths = self.get_file_paths(config.WD_MATCHING_PATH)
+
+        if not paths:
+            log.warning(
+                "No matching files for withdrawals/deposits located in %s.",
+                config.WD_MATCHING_PATH,
+            )
+            return False
+
+        for file_path in paths:
+            #TODO match withdrawals/deposits
+            pass
+
+        if not bool(self):
+            log.warning("Unable to import any data.")
+            return False
+
+        return True
+
     def read_file(self, file_path: Path) -> None:
         """Import transactions form an account statement.
 

--- a/src/book.py
+++ b/src/book.py
@@ -1137,20 +1137,20 @@ class Book:
                 "Skipping file."
             )
 
-    def get_account_statement_paths(self, statements_dir: Path) -> list[Path]:
-        """Return file paths of all account statements in `statements_dir`.
+    def get_file_paths(self, folder_dir: Path) -> list[Path]:
+        """Return file paths of all input files in `folder_dir`.
+        For example, this function can return all account statement file paths.
 
         Args:
-            statements_dir (str): Folder in which account statements
-                                  will be searched.
+            folder_dir (str): Folder in input files will be searched.
 
         Returns:
-            list[Path]: List of account statement file paths.
+            list[Path]: List of input file paths.
         """
         file_paths: list[Path] = []
 
-        if statements_dir.is_dir():
-            for file_path in statements_dir.iterdir():
+        if folder_dir.is_dir():
+            for file_path in folder_dir.iterdir():
                 # Ignore .gitkeep and temporary excel files.
                 filename = file_path.stem
                 if filename == ".gitkeep" or filename.startswith("~$"):
@@ -1165,7 +1165,7 @@ class Book:
         Returns:
             bool: Return True if everything went as expected.
         """
-        paths = self.get_account_statement_paths(config.ACCOUNT_STATMENTS_PATH)
+        paths = self.get_file_paths(config.ACCOUNT_STATMENTS_PATH)
 
         if not paths:
             log.warning(

--- a/src/config.py
+++ b/src/config.py
@@ -59,4 +59,5 @@ BASE_PATH = Path(__file__).parent.parent.absolute()
 ACCOUNT_STATMENTS_PATH = Path(BASE_PATH, "account_statements")
 DATA_PATH = Path(BASE_PATH, "data")
 EXPORT_PATH = Path(BASE_PATH, "export")
+WD_MATCHING_PATH = Path(BASE_PATH, "withdrawals_deposits")
 FIAT = FIAT_CLASS.name  # Convert to string.

--- a/src/main.py
+++ b/src/main.py
@@ -40,8 +40,8 @@ def main() -> None:
     # 1) Find matching withdrawal and deposit or raise a warning
     # 2) Withdraw deposits from one exchange with FIFO/LIFO principle
     #    to the other exchange
-    # log.debug("Resolve withdrawals and deposits between exchanges...")
-    # book.resolve_deposits()
+    log.debug("Resolve withdrawals and deposits between exchanges...")
+    book.resolve_deposits()
     book.get_price_from_csv()
     taxman.evaluate_taxation()
     taxman.export_evaluation_as_csv()

--- a/src/main.py
+++ b/src/main.py
@@ -35,6 +35,13 @@ def main() -> None:
         log.warning("Stopping CoinTaxman.")
         return
 
+    # TODO Resolve withdrawals and deposits between exchanges (#4)
+    # 1) Find matching withdrawal and deposit or raise a warning
+    # 2) Withdraw deposits from one exchange with FIFO/LIFO principle
+    #    to the other exchange
+    # log.debug("Resolve withdrawals and deposits between exchanges...")
+    # book.resolve_deposits()
+
     taxman.evaluate_taxation()
     taxman.export_evaluation_as_csv()
     taxman.print_evaluation()

--- a/src/transaction.py
+++ b/src/transaction.py
@@ -35,6 +35,7 @@ class Operation:
     coin: str
     line: int
     file_path: Path
+    buy_platform: typing.Optional[str] = None
 
     def __post_init__(self):
         assert self.validate_types()


### PR DESCRIPTION
Closes https://github.com/provinzio/CoinTaxman/issues/4

### Dependencies that should be finished first

- [ ] Close PR https://github.com/provinzio/CoinTaxman/pull/98: This PR contains many changes in the balancing/taxation loop. Merging would be easier if this is done first. Once we separate balancing and taxation in two loops, we might get many merge conflicts and have to resolve them manually . However, not strictly required.

### To-do list

- [ ] Split up balancing and taxation in two different loops
- [ ] Add additional variable `acquire_platform` or similar to operations
- [ ] Change price fetching logic accordingly (use the correct `acquire_platform` or `platform`)
- [ ] Implement read-in of config files to match withdrawals and deposits (similar to https://github.com/provinzio/CoinTaxman/pull/115)
- [ ] Resolve deposits and withdrawals based on matching file
- [ ] Move coins between platforms, balancing for each platform (happens before taxation)