### PR TITLE
Resolve Withdrawals/Deposits

### DIFF
--- a/src/book.py
+++ b/src/book.py
@@ -1236,7 +1236,6 @@ class Book:
         withdrawal_queue: list[tr.Withdrawal] = []
 
         for op in sorted_ops:
-            # log.debug(op.utc_time)
             if isinstance(op, tr.Withdrawal):
                 if not misc.is_fiat(op.coin):
                     withdrawal_queue.append(op)

--- a/src/book.py
+++ b/src/book.py
@@ -1251,8 +1251,8 @@ class Book:
                 except StopIteration:
                     log.warning(
                         "No matching withdrawal operation found for deposit of "
-                        f"{match.change} {match.coin} "
-                        f"({match.platform}, {match.utc_time}). "
+                        f"{op.change} {op.coin} "
+                        f"({op.platform}, {op.utc_time}). "
                         "The tax evaluation might be wrong. "
                         "Have you added all account statements? "
                         "For tax evaluation, it might be importend when "

--- a/src/book.py
+++ b/src/book.py
@@ -1237,10 +1237,10 @@ class Book:
 
         for op in sorted_ops:
             if isinstance(op, tr.Withdrawal):
-                if not misc.is_fiat(op.coin):
+                if op.coin != config.FIAT:
                     withdrawal_queue.append(op)
             elif isinstance(op, tr.Deposit):
-                if not misc.is_fiat(op.coin):
+                if op.coin != config.FIAT:
                     try:
                         match = next(w for w in withdrawal_queue if is_match(w, op))
                         op.link = match

--- a/src/main.py
+++ b/src/main.py
@@ -44,6 +44,7 @@ def main() -> None:
     # (as long as there are only one buy/sell pair per time,
     # might be problematic otherwhise).
     book.merge_identical_operations()
+    book.resolve_deposits()
     book.get_price_from_csv()
     book.match_fees_with_operations()
 

--- a/src/main.py
+++ b/src/main.py
@@ -44,6 +44,8 @@ def main() -> None:
     # (as long as there are only one buy/sell pair per time,
     # might be problematic otherwhise).
     book.merge_identical_operations()
+    # Resolve dependencies between withdrawals and deposits, which is
+    # necessary to correctly fetch prices and to calculate p/l.
     book.resolve_deposits()
     book.get_price_from_csv()
     book.match_fees_with_operations()

--- a/src/transaction.py
+++ b/src/transaction.py
@@ -190,7 +190,7 @@ class Commission(Transaction):
 
 
 class Deposit(Transaction):
-    pass
+    link: typing.Optional[Withdrawal] = None
 
 
 class Withdrawal(Transaction):

--- a/src/transaction.py
+++ b/src/transaction.py
@@ -190,7 +190,7 @@ class Commission(Transaction):
 
 
 class Deposit(Transaction):
-    link: typing.Optional[Withdrawal] = None
+    link: Optional[Withdrawal] = None
 
 
 class Withdrawal(Transaction):


### PR DESCRIPTION
This is the follow-up for #116.

Contains a simple algorithm which matches related withdrawals and deposits.

Deposits now have a `link` property containing a reference to the matching withdrawal.
The algorithm checks that:

1. the coin matches
2. the deposit change is between .99 and 1 times the withdrawal change (accounting for potential fees).