### PR TITLE
Add deposit when buying with fiat

### DIFF
--- a/src/book.py
+++ b/src/book.py
@@ -413,6 +413,18 @@ class Book:
                     # If it's a buy, add the corresponding sell to complement
                     # the trading pair.
                     elif operation == "Buy":
+                        # If coins were bought with fiat, first add a corresponding deposit
+                        if misc.is_fiat(_currency_spot):
+                            eur_total = misc.force_decimal(_eur_total)
+                            self.append_operation(
+                                "Deposit",
+                                utc_time,
+                                platform,
+                                eur_total,
+                                _currency_spot,
+                                row,
+                                file_path,
+                            )
                         assert isinstance(eur_subtotal, decimal.Decimal)
                         self.append_operation(
                             "Sell",
@@ -435,7 +447,7 @@ class Book:
         self._read_coinbase(file_path=file_path)
 
     def _read_coinbase_pro(self, file_path: Path) -> None:
-        platform = "coinbase_pro"
+        platform = "coinbase"
         operation_mapping = {
             "BUY": "Buy",
             "SELL": "Sell",


### PR DESCRIPTION
This adds a deposit operation when buying coins with fiat on coinbase.
Also sets the platform from "coinbase_pro" to "coinbase" to remove issue regarding transfers between the two.

Tracking issue: #138 