### PR TITLE
Bitpanda changed fileformat

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -28,4 +28,7 @@ LOG_LEVEL = DEBUG
 # If False, all airdrops will be taxed as `Einkünfte aus sonstigen Leistungen`.
 # Setting this config falsly will result in a wrong tax calculation.
 # Please inform yourself and help to resolve this issue by working on/with #115.
+# Some airdrops can be classified as gifts (Schenkung) or income (Eink├╝nfte)
+# relatively savely. For those, there is a flag to signal either type.
+# See the AirdropGift and AirdropIncome classes in transaction.py and their usage in book.py
 ALL_AIRDROPS_ARE_GIFTS = True

--- a/config.ini
+++ b/config.ini
@@ -28,7 +28,7 @@ LOG_LEVEL = DEBUG
 # If False, all airdrops will be taxed as `Einkünfte aus sonstigen Leistungen`.
 # Setting this config falsly will result in a wrong tax calculation.
 # Please inform yourself and help to resolve this issue by working on/with #115.
-# Some airdrops can be classified as gifts (Schenkung) or income (Eink├╝nfte)
+# Some airdrops can be classified as gifts (Schenkung) or income (Einkünfte)
 # relatively savely. For those, there is a flag to signal either type.
 # See the AirdropGift and AirdropIncome classes in transaction.py and their usage in book.py
 ALL_AIRDROPS_ARE_GIFTS = True

--- a/src/config.py
+++ b/src/config.py
@@ -69,7 +69,7 @@ if COUNTRY == core.Country.GERMANY:
     PRINCIPLE = core.Principle.FIFO
     LOCAL_TIMEZONE = zoneinfo.ZoneInfo("CET")
     LOCAL_TIMEZONE_KEY = "MEZ"
-    locale_str = "de_DE"
+    locale_str = ["de_DE", "de_DE.utf8"] # try multiple german locales in order
 
 else:
     raise NotImplementedError(
@@ -79,4 +79,9 @@ else:
 
 # Program specific constants.
 FIAT = FIAT_CLASS.name  # Convert to string.
-locale.setlocale(locale.LC_ALL, locale_str)
+for loc in locale_str:
+    try:
+        locale.setlocale(locale.LC_ALL, loc)
+    except:
+        continue
+    break

--- a/src/price_data.py
+++ b/src/price_data.py
@@ -355,8 +355,10 @@ class PriceData:
                     )
                 r = requests.get(baseurl, params=params)
 
-                assert r.status_code == 200, f"No valid response from ONE TRADING (ex Bitpanda Pro) API\nError: {r.json()['error']}"
                 data = r.json()
+                if r.status_code == 400 and data["error"] == f"The requested market {base_asset}_{quote_asset} is not available.":
+                    raise ValueError(data["error"])
+                assert r.status_code == 200, f"No valid response from ONE TRADING (ex Bitpanda Pro) API\nError: {r.json()['error']}"
 
                 # exit loop if data is valid
                 if data:
@@ -380,11 +382,12 @@ class PriceData:
             raise RuntimeError
 
         # this should never be triggered, but just in case assert received data
-        assert data, f"No valid price data for {base_asset} / {quote_asset} at {end}"
+        assert data["candlesticks"], f"No valid price data for {base_asset} / {quote_asset} at {end}"
+        data = data["candlesticks"]
 
-        # simply take the average of the latest data element
-        high = misc.force_decimal(data[-1]["high"])
-        low = misc.force_decimal(data[-1]["low"])
+        # simply take the average of the first data element
+        high = misc.force_decimal(data[0]["high"])
+        low = misc.force_decimal(data[0]["low"])
 
         # if spread is greater than 3%
         if (high - low) / high > 0.03:
@@ -607,24 +610,39 @@ class PriceData:
         reference_coin: str = config.FIAT,
     ) -> decimal.Decimal:
         op = op_sc if isinstance(op_sc, tr.Operation) else op_sc.op
-        if op.coin in ["ETHW", "BEST"] and op.platform == "bitpanda":
-            # ETHW and BEST are not available via ONE TRADING (ex Bitpanda Pro) API
-            # => use the price from the exported data.
-            if op.exported_price is not None:
-                return op.exported_price
-            if op.coin == "BEST" and isinstance(op, tr.Fee):
+        try:
+            price = self.get_price(op.platform, op.coin, op.utc_time, reference_coin)
+        except ValueError as e:
+            log.warning(
+                f"The API didn't provide a valid response. Using the price from the csv file if possible.\n"
+                f"\t\tCoin: {op.coin} | Op: {type(op).__name__} | Platform: {op.platform} | Row: {op.line} | File: {op.file_path}\n"
+                f"\t\tCaught exception: {e}"
+            )
+            if op.platform == "bitpanda":
+                # LUNC, ETHW, BEST and maybe more are not available via ONE TRADING (ex Bitpanda Pro) API
+                # => use the price from the exported data.
+                if op.exported_price is not None:
+                    price = op.exported_price
+
                 # Fees paid with BEST don't have a value given in the exported data.
                 # The value also can't be queried from the ONE TRADING (ex Bitpanda Pro) API (anymore)
+                if op.coin == "BEST" and isinstance(op, tr.Fee):
+                    log.warning(
+                        f"Can't get price for '{type(op).__name__}' of {op.coin} on platform {op.platform} anymore.\n"
+                        f"A withdrawal of BEST on bitpanda is likely a deduction of fees. For now we'll assume a value of 0.\n"
+                        f"For accurately calculating fees, this needs to be fixed. PRs welcome!\n"
+                        f"(row {op.line} in {op.file_path}"
+                    )
+                    return 0
+            else:
                 log.warning(
-                    f"Can't get price for '{type(op).__name__}' of {op.coin} on platform {op.platform} for operation 'Withdrawal' anymore.\n"
-                    f"A withdrawal of BEST on bitpanda is likely a deduction of fees. For now we'll assume a value of 0.\n"
-                    f"For accurately calculating fees, this needs to be fixed. PRs welcome!\n"
-                    f"(row {op.line} in {op.file_path}"
+                    f"Could not get any price info for {type(op).__name__} {op.coin} on {op.platform}! "
+                    f"Row: {op.line} | File: {op.file_path}"
                 )
-                return 0
-            raise RuntimeError(f"Can't get price for '{type(op).__name__}' of {op.coin} on platform {op.platform} (row {op.line} in {op.file_path})!")
-        else:
-            price = self.get_price(op.platform, op.coin, op.utc_time, reference_coin)
+                raise RuntimeError(e)
+
+        # This may fail if an exchange is queried for a non existant coin/fiat pair and the operation doesn't include an exported price.
+        assert price, f"Could not get a price for asset {op.coin} at {op.utc_time}"
 
         if isinstance(op_sc, tr.Operation):
             return price * op_sc.change

--- a/src/taxman.py
+++ b/src/taxman.py
@@ -261,8 +261,8 @@ class Taxman:
         Raises:
             NotImplementedError: When there are more than two different fee coins.
         """
-        assert op.coin == sc.op.coin
-        assert op.change >= sc.sold
+        assert op.coin == sc.op.coin, f"Error evaluating op.coin==sc.op.coin:\n\t\t{op}\n\t\t{sc}"
+        assert op.change >= sc.sold, f"Error evaluating op.change >=sc.sold:\n\t\t{op}\n\t\t{sc}"
 
         # Share the fees and sell_value proportionally to the coins sold.
         percent = sc.sold / op.change
@@ -284,7 +284,7 @@ class Taxman:
         except Exception as e:
             if ReportType is tr.UnrealizedSellReportEntry:
                 log.warning(
-                    "Catched the following exception while trying to query an "
+                    "Caught the following exception while trying to query an "
                     f"unrealized sell value for {sc.sold} {sc.op.coin} at deadline "
                     f"on platform {sc.op.platform}. "
                     "If you want to see your unrealized sell value "
@@ -294,7 +294,7 @@ class Taxman:
                     "The sell value for this calculation will be set to 0. "
                     "Your unrealized sell summary will be wrong and will not "
                     "be exported.\n"
-                    f"Catched exception: {e}"
+                    f"Caught exception: {type(e).__name__}: {e}"
                 )
                 sell_value_in_fiat = decimal.Decimal()
                 self.unrealized_sells_faulty = True

--- a/src/taxman.py
+++ b/src/taxman.py
@@ -486,6 +486,12 @@ class Taxman:
                     taxation_type = "Schenkung"
                 else:
                     taxation_type = "Einkünfte aus sonstigen Leistungen"
+
+                # If taxation_type is actually set, it should overwrite the general setting.
+                # This can happen by using the subclasses AirdropGift (not taxed) and AirdropIncome (taxed)
+                if op.taxation_type:
+                    taxation_type = op.taxation_type
+
                 report_entry = tr.AirdropReportEntry(
                     platform=op.platform,
                     amount=op.change,

--- a/src/transaction.py
+++ b/src/transaction.py
@@ -190,8 +190,17 @@ class StakingInterest(Transaction):
 
 
 class Airdrop(Transaction):
-    pass
+    taxation_type: Optional[str] = None
 
+class AirdropGift(Airdrop):
+    """AirdropGift is used for gifts that are non-taxable"""
+
+    taxation_type: Optional[str] = "Schenkung"
+
+class AirdropIncome(Airdrop):
+    """AirdropIncome is used for income that is taxable"""
+
+    taxation_type: Optional[str] = "Einkünfte aus sonstigen Leistungen"
 
 class Commission(Transaction):
     pass

--- a/src/transaction.py
+++ b/src/transaction.py
@@ -46,6 +46,7 @@ class Operation:
     line: list[int]
     file_path: Path
     fees: "Optional[list[Fee]]" = None
+    exported_price: "Optional[decimal.Decimal]" = None # can hold the price from the exported data (csv)
     remarks: list[str] = dataclasses.field(default_factory=list)
 
     @property
@@ -87,6 +88,10 @@ class Operation:
                 # TODO currently kind of ignored, would be nice when
                 #      implemented correctly.
                 assert actual_value is None
+                continue
+
+            if field.name == "exported_price":
+                assert (actual_value is None or isinstance(actual_value, decimal.Decimal))
                 continue
 
             actual_type = typing.get_origin(field.type) or field.type


### PR DESCRIPTION
# This PR deals with some developments for Bitpanda, which are roughly:

* Bitpanda Pro is now One Trading and doesn't share data with Bitpanda anymore. As a result, the Bitpanda Pro API, that was also used for Bitpanda to fetch prices, is moved to a different address and doesn't offer the same markets (coin/EUR) as Bitpanda anymore. (Related: #159 )
*  The Bitpanda export has a new column (Related: #159 )
*  Bitpandas logging of transactions changed a bit over time and didn't provide a lot of details in the beginning. As a result, staking actions (staking, unstaking, rewards) and other airdrops were logged as "transfer". Some of those cases can be handled and corrected automatically. (Fixes: #155 )
* In the past years, there were at least two forks that I was affected by: ETHW (the PoW fork of ETH) and LUNC (crashed fork of LUNA). Users who held those coins when the fork happened received some amount of the fork coin as air drop. Taxation of those is not entirely clear but there are some arguments available (see the detailed changes for more info). My PR classifies those as AirdropGift (non-taxable) but doesn't try to add a history or fork operation as discussed in #131 .

## The detailed changes from 3 commits:

* cfg fix: The de_DE locale doesn't work on my system. I've changed it to try different locales in order ("de_DE", "de_DE.utf-8")
* general: Created AirdropGift (non-taxed) and AirdropIncome (taxed) as subclasses of Airdrop. AirdropGifts are always non-taxed and AirdropIncome are always taxed, no matter the setting `ALL_AIRDROPS_ARE_GIFTS` in the config. These subclasses can be used if it is save to say that a record is to be taxed or not.
* bitpanda general: Current csv exports have an additional field that tripped up the parsing. Added the field `_tax_fiat` to the header definition. TODO: check if the contained information is relevant.
* bitpanda airdrop types: Implemented AirdropGift for BEST and ETHW drops (see below).
* bitpanda stocks: Ignore records where the asset type starts with "Stock" (for now)
* bitpanda BEST transfer: BEST is bitpandas own coin and is rewarded for activity and holding a portfolio. These are classified as AirdropGift (non-taxable).
* bitpanda ETHW transfer: ETHW is the old ETH chain. If a user held ETH with bitpanda when the fork to PoS happened, they received ETHW some time in September 2022. Classify that as AirdropGift according to the first reasoning described [here](https://www.winheller.com/bankrecht-finanzrecht/bitcointrading/bitcoinundsteuer/besteuerung-hardforks-ledger-splits.html)
* bitpanda staking: Implemented handling of staking for `transfer(stake)` and `transfer(unstake)` operation types.
*  general: Added new data field `exported_price` to `Operation` class
* bitpanda general: For ETHW and BEST, the `exported_price` will be used because the ONE TRADING API doesn't return anything.
* bitpanda general fix: The `change` calculation used a change from an earlier data record for some operation types,
  because the `change` variable was not touched (for Airdrops of any kind and Staking operations of any kind).
  The missing operations are now added in `_read_bitpanda` in book.py and an Exception has been added for anything else not
  included in my change.
* bitpanda general: Bitpanda Pro, whose API we use to fetch prices for bitpanda transactions, is now One Trading. As a result, their API is available under a different address and with a slightly different response. This commit contains the fixes for both, the address and the parsing/usage of the result.
* bitpanda general: Since One Trading doesn't offer the same coins as Bitpanda anymore, some coin/fiat pairs aren't available there (like BEST/EUR, ETHW/EUR, LTC/EUR and others). To differentiate between a "market" not being available and other errors, we raise a ValueError in case the "market" is not available. I chose ValueError because catching LookupError also catches errors with indices in lists, which should be thrown.
* bitpanda general: The ValueError is caught in price_data.py in the `get_cost` method. In the last commit, I added a new field `exported_price` to the `Operation` data class, which is used in the exception handling to use the price from the csv export (it's better than nothing). For BEST, there is sadly no price available if the BEST transaction is a Withdrawal (Fee). For now, we assume a value of 0 in that case (I don't know how to fix this otherwise).
* bitpanda LUNC airdrop: I added special handling for the LUNC airdrop that happened in May 2022 because of a blockchain crash and subsequent fork. Sadly, the price can't be retrieved using the API and the airdrop didn't have a price associated. CoinTaxman should throw an exception because it can't fetch a price and it should also say which line the airdrop is in. I used that to edit my csv export and input a ridiculously small price since the price was really low anyway.
* bitpanda staking rewards: Sometime before 2022/6/14, bitpanda used "transfer" for staking rewards. Incoming crypto "transfers" before that date, that aren't BEST, are therefore classified as (staking-)reward.

## Background of the Bitpanda Pro spin off into One Trading:

Bitpanda Pro, which is used to obtain historical prices for (crypto-)assets
is now ONE TRADING and a separate company to which Bitpanda only holds a minority stake.
After that split, BEST can't be used anymore on ONE TRADING and historical BEST price data isn't available anymore.
Also, ETHW, which stands for the Proof of Work branch of the ETH chain, isn't available on ONE TRADING.

This means, that we need to use the prices we have from the csv file as best as we can.
For normal transactions, that's possible by using the "Asset market price" column of the export but for fee withdrawals
from the BEST wallet, no price was actually associated with the withdrawal transaction.
For now, I'm using an asset price of 0 because I don't know how to fix this otherwise.

For the normal transactions, a new property has been added to the Operation class (`exported_price`) to be able to
carry the asset price for normal transactions into the processing classes like PriceData and use it there
if a proper price can't be obtained (see `get_cost` method in `PriceData` in price_data.py).

Source: https://support.bitpanda.com/hc/en-us/articles/9374684386332-Why-is-Bitpanda-Pro-evolving-to-become-One-Trading